### PR TITLE
Add Vaultwarden helper and API skeleton

### DIFF
--- a/app-main/lib/vaultwarden.ts
+++ b/app-main/lib/vaultwarden.ts
@@ -1,0 +1,18 @@
+// Handles token + unlock, nothing else.
+import axios from 'axios';
+
+export async function getToken(apiUrl: string, id: string, secret: string) {
+  const body = new URLSearchParams({
+    client_id: id,
+    client_secret: secret,
+    grant_type: 'client_credentials',
+    scope: 'api',
+  });
+  return axios.post(`${apiUrl}/identity/connect/token`, body);
+}
+
+export async function syncVault(apiUrl: string, bearer: string) {
+  return axios.get(`${apiUrl}/api/sync`, {
+    headers: { Authorization: `Bearer ${bearer}` },
+  });
+}

--- a/app-main/pages/api/vault/login.ts
+++ b/app-main/pages/api/vault/login.ts
@@ -1,0 +1,13 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getToken } from '../../../lib/vaultwarden';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') return res.status(405).end();
+  const { url, clientId, clientSecret } = req.body;
+  try {
+    const { data } = await getToken(url, clientId, clientSecret);
+    res.status(200).json(data);          // {access_token, refresh_token, Key, ...}
+  } catch (e: any) {
+    res.status(400).json({ error: e.message });
+  }
+}

--- a/app-main/pages/api/vault/sync.ts
+++ b/app-main/pages/api/vault/sync.ts
@@ -1,0 +1,12 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { syncVault } from '../../../lib/vaultwarden';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { apiUrl, token } = req.body;
+  try {
+    const { data } = await syncVault(apiUrl, token);
+    res.status(200).json(data);          // returns encrypted vault JSON
+  } catch (e: any) {
+    res.status(400).json({ error: e.message });
+  }
+}

--- a/app-main/pages/vault.tsx
+++ b/app-main/pages/vault.tsx
@@ -1,0 +1,40 @@
+import { useState } from 'react';
+
+export default function Vault() {
+  const [url, setUrl] = useState('https://vault.example.com');       // default server
+  const [id, setId] = useState('');      // client_id
+  const [secret, setSecret] = useState('');  // client_secret
+  const [master, setMaster] = useState('');  // master password
+  const [token, setToken] = useState('');
+  const [status, setStatus] = useState('');
+
+  async function handleLogin(e: React.FormEvent) {
+    e.preventDefault();
+    setStatus('Getting token…');
+    const r = await fetch('/api/vault/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ url, clientId: id, clientSecret: secret }),
+    }).then(r => r.json());
+
+    if (r.access_token) {
+      setToken(r.access_token);                   // store in memory; persist as needed
+      setStatus('Token OK – now unlock vault locally');
+      // TODO: derive KDF & decrypt r.Key with `master`, then call /api/vault/sync
+    } else setStatus('Login failed');
+  }
+
+  return (
+    <div className="max-w-md mx-auto p-8">
+      <h1 className="text-2xl font-bold mb-4">Vault Login</h1>
+      <form onSubmit={handleLogin} className="space-y-4">
+        <input className="w-full p-2 border" value={url}     onChange={e=>setUrl(e.target.value)}     placeholder="Vaultwarden URL" />
+        <input className="w-full p-2 border" value={id}      onChange={e=>setId(e.target.value)}      placeholder="client_id" />
+        <input className="w-full p-2 border" value={secret}  onChange={e=>setSecret(e.target.value)}  placeholder="client_secret" />
+        <input className="w-full p-2 border" type="password" value={master} onChange={e=>setMaster(e.target.value)} placeholder="master password" />
+        <button className="bg-primary text-white px-4 py-2 rounded" type="submit">Login &amp; Sync</button>
+      </form>
+      <p className="mt-4 text-sm">{status}</p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a helper for talking to Vaultwarden
- create server-side routes for login and sync
- provide a basic `/vault` page to test the API

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f42ab42a0832c936ec666dc0f4d88