### PR TITLE
Add axios dependency

### DIFF
--- a/app-main/package.json
+++ b/app-main/package.json
@@ -17,6 +17,7 @@
     "@heroicons/react": "^2.2.0",
     "@supabase/supabase-js": "^2.47.14",
     "cheerio": "^1.0.0",
+    "axios": "^1.6.8",
     "next": "^15.1.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"


### PR DESCRIPTION
## Summary
- add axios dependency for Vaultwarden client

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f44d15864832c8f25511536d824ba