### PR TITLE
Fix Vaultwarden token request

### DIFF
--- a/app-main/lib/vaultwarden.ts
+++ b/app-main/lib/vaultwarden.ts
@@ -1,5 +1,9 @@
 // lib/vaultwarden.ts
 import axios from 'axios';
+import { randomUUID } from 'crypto';
+
+// Stable device identifier for the runtime. Persist if you need it across runs.
+const deviceId = randomUUID();
 
 export async function getToken(apiUrl: string, id: string, secret: string) {
   const body = new URLSearchParams({
@@ -7,9 +11,19 @@ export async function getToken(apiUrl: string, id: string, secret: string) {
     client_secret: secret,
     grant_type: 'client_credentials',
     scope: 'api',
+    // Vaultwarden requires these three additional fields
+    deviceIdentifier: deviceId,
+    deviceName: 'nextjs-app',
+    deviceType: '8',
   }).toString();                                // <- stringify
 
   return axios.post(`${apiUrl}/identity/connect/token`, body, {
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' }, // <- force header
+  });
+}
+
+export async function syncVault(apiUrl: string, token: string) {
+  return axios.get(`${apiUrl}/api/sync`, {
+    headers: { Authorization: `Bearer ${token}` },
   });
 }


### PR DESCRIPTION
## Summary
- include device information in OAuth token request to avoid 400 errors
- add missing `syncVault` helper

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: next not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683f4db99574832c83ed3388086344e1