### PR TITLE
Add vault decryption

### DIFF
--- a/app-main/lib/decryptVault.ts
+++ b/app-main/lib/decryptVault.ts
@@ -1,0 +1,44 @@
+import { decryptCipherString, unlockVault, KdfType } from './vaultCrypto';
+
+export interface DecryptedCipher {
+  id: string;
+  name: string;
+  username?: string;
+  password?: string;
+}
+
+/**
+ * Decrypt vault ciphers using the master password.
+ * Expects sync data from /api/sync.
+ */
+export async function decryptVault(syncData: any, masterPassword: string): Promise<DecryptedCipher[]> {
+  const profile = syncData.profile;
+  if (!profile) throw new Error('Missing profile');
+
+  const kdfType: KdfType = profile.kdf ?? profile.Kdf;
+  const kdfIterations: number = profile.kdfIterations ?? profile.KdfIterations;
+  const kdfMemory: number = profile.kdfMemory ?? profile.KdfMemory ?? 65536;
+  const kdfParallelism: number = profile.kdfParallelism ?? profile.KdfParallelism ?? 4;
+
+  const { encKey, macKey } = await unlockVault(
+    profile.key,
+    masterPassword,
+    profile.email,
+    kdfType,
+    kdfIterations,
+    kdfMemory,
+    kdfParallelism,
+  );
+
+  const items: DecryptedCipher[] = [];
+  for (const c of syncData.ciphers ?? []) {
+    const item: DecryptedCipher = {
+      id: c.id,
+      name: await decryptCipherString(c.name, encKey, macKey),
+    };
+    if (c.login?.username) item.username = await decryptCipherString(c.login.username, encKey, macKey);
+    if (c.login?.password) item.password = await decryptCipherString(c.login.password, encKey, macKey);
+    items.push(item);
+  }
+  return items;
+}


### PR DESCRIPTION
## Summary
- add a small helper to decrypt vault items using the master password
- show decrypted vault items on the `/vault` page when `NEXT_PUBLIC_MASTER_PASSWORD` is present

## Testing
- `npx next build` *(fails: needs interactive install)*

------
https://chatgpt.com/codex/tasks/task_e_6840b9cf5b14832c82827f7079a50c9b