### PR TITLE
Implement vault diagram viewer

### DIFF
--- a/app-main/components/UploadZone.tsx
+++ b/app-main/components/UploadZone.tsx
@@ -1,0 +1,21 @@
+'use client'
+import { useCallback } from 'react'
+import { useDropzone } from 'react-dropzone'
+import { saveVault } from '@/lib/storage'
+
+export default function UploadZone({ onLoad }:{ onLoad:(json:any)=>void }){
+  const onDrop = useCallback((files:File[])=>{
+    const file = files[0]
+    file.text().then(txt=>{
+      try{ onLoad(JSON.parse(txt)); saveVault(txt) }
+      catch{ alert('Invalid export') }
+    })
+  },[onLoad])
+  const {getRootProps,getInputProps,isDragActive}=useDropzone({onDrop,accept:{'application/json':['.json','.csv']}})
+  return (
+    <div {...getRootProps()} className={`border-2 border-dashed p-8 text-center ${isDragActive?'bg-indigo-50':''}`}>
+      <input {...getInputProps()} />
+      Drop Bitwarden export here or click to select
+    </div>
+  )
+}

--- a/app-main/components/VaultDiagram.tsx
+++ b/app-main/components/VaultDiagram.tsx
@@ -1,0 +1,17 @@
+'use client'
+import ReactFlow, { MiniMap, Controls, Background } from 'reactflow'
+import 'reactflow/dist/style.css'
+import { useGraph } from '@/contexts/GraphStore'
+
+export default function VaultDiagram(){
+  const { nodes, edges } = useGraph()
+  return (
+    <div style={{height:'70vh'}}>
+      <ReactFlow nodes={nodes} edges={edges} fitView>
+        <MiniMap />
+        <Controls />
+        <Background />
+      </ReactFlow>
+    </div>
+  )
+}

--- a/app-main/contexts/GraphStore.ts
+++ b/app-main/contexts/GraphStore.ts
@@ -1,0 +1,16 @@
+'use client'
+import { create } from 'zustand'
+import { Edge, Node } from 'reactflow'
+import { VaultGraph } from '@/lib/parseVault'
+
+interface GraphState {
+  nodes: Node[]
+  edges: Edge[]
+  setGraph: (g: VaultGraph)=>void
+}
+
+export const useGraph = create<GraphState>(set=>({
+  nodes: [],
+  edges: [],
+  setGraph: g => set(g),
+}))

--- a/app-main/lib/parseVault.ts
+++ b/app-main/lib/parseVault.ts
@@ -1,0 +1,27 @@
+import { Edge, Node } from 'reactflow'
+
+export const parseVault = (vault:any)=>{
+  const nodes:Node[]=[]
+  const edges:Edge[]=[]
+  if(!vault?.items) return {nodes,edges}
+  vault.items.forEach((item:any)=>{
+    const itemId=`item-${item.id}`
+    nodes.push({ id:itemId, position:{x:0,y:0}, data:{label:item.name}, type:'default' })
+    ;(item.login?.uris||[]).forEach((u:any,i:number)=>{
+      try{
+        const url=new URL(u.uri); const domain=url.hostname
+        const emailKey=item.login?.username?.includes('@')?item.login.username:undefined
+        if(emailKey){
+          const emailId=`email-${emailKey}`
+          if(!nodes.find(n=>n.id===emailId)) nodes.push({ id:emailId, position:{x:0,y:0}, data:{label:emailKey}, type:'default' })
+          edges.push({ id:`e-${itemId}-${emailId}-${i}`, source:itemId, target:emailId })
+        }
+        const domId=`dom-${domain}`
+        if(!nodes.find(n=>n.id===domId)) nodes.push({ id:domId, position:{x:0,y:0}, data:{label:domain}, type:'default' })
+        edges.push({ id:`e-${itemId}-${domId}-${i}`, source:itemId, target:domId })
+      }catch{}
+    })
+  })
+  return {nodes,edges}
+}
+export type VaultGraph = ReturnType<typeof parseVault>

--- a/app-main/lib/storage.ts
+++ b/app-main/lib/storage.ts
@@ -1,0 +1,10 @@
+import { parseVault } from './parseVault'
+
+const KEY = 'vault-data'
+
+export const saveVault = (raw:string)=>{
+  try{ localStorage.setItem(KEY, raw) }catch{}
+}
+export const loadVault = ()=>{
+  try{ const raw = localStorage.getItem(KEY); return raw? parseVault(JSON.parse(raw)):null }catch{ return null }
+}

--- a/app-main/package.json
+++ b/app-main/package.json
@@ -16,12 +16,16 @@
   "dependencies": {
     "@heroicons/react": "^2.2.0",
     "@supabase/supabase-js": "^2.47.14",
+    "@tanstack/react-query": "^5.80.5",
     "argon2-browser": "^1.18.0",
     "axios": "^1.6.8",
     "cheerio": "^1.0.0",
     "next": "^15.1.3",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "react-dropzone": "^14.3.8",
+    "reactflow": "^11.11.4",
+    "zustand": "^5.0.5"
   },
   "devDependencies": {
     "@types/node": "^22.10.2",

--- a/app-main/pages/_app.tsx
+++ b/app-main/pages/_app.tsx
@@ -1,7 +1,15 @@
 // pages/_app.tsx
-import '../styles/globals.css';
-import type { AppProps } from 'next/app';
+import '../styles/globals.css'
+import type { AppProps } from 'next/app'
+import { useEffect } from 'react'
+import { useGraph } from '@/contexts/GraphStore'
+import { loadVault } from '@/lib/storage'
 
 export default function App({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />;
+  const { setGraph } = useGraph()
+  useEffect(()=>{
+    const g = loadVault()
+    if(g) setGraph(g)
+  },[setGraph])
+  return <Component {...pageProps} />
 }

--- a/app-main/pages/vault.tsx
+++ b/app-main/pages/vault.tsx
@@ -1,120 +1,14 @@
-// app-main/pages/vault.tsx – uses values from .env.local so there are **no input fields**
-// -----------------------------------------------------------------------------
-// Expected entries in `.env.local` (note the NEXT_PUBLIC_ prefix so the browser
-// can read them):
-// NEXT_PUBLIC_VAULT_URL=https://vault.vezit.net
-// NEXT_PUBLIC_CLIENT_ID=user.1bcfca12-82a6-49f3-bae9-2907d78cd9c0
-// NEXT_PUBLIC_CLIENT_SECRET=0SwiBZV8dyVvPmZ6H4fAJjUA6SY2KT
-// # optional – only needed when you later decrypt the vault
-// NEXT_PUBLIC_MASTER_PASSWORD=myMasterPassword
-// -----------------------------------------------------------------------------
+import UploadZone from '@/components/UploadZone'
+import VaultDiagram from '@/components/VaultDiagram'
+import { parseVault } from '@/lib/parseVault'
+import { useGraph } from '@/contexts/GraphStore'
 
-import { useState } from 'react';
-import { decryptVault, DecryptedCipher } from '../lib/decryptVault';
-
-/** Grab secrets from the env (Next.js exposes only *NEXT_PUBLIC_* on the client) */
-const API_URL        = process.env.NEXT_PUBLIC_VAULT_URL     ?? '';
-const CLIENT_ID      = process.env.NEXT_PUBLIC_CLIENT_ID     ?? '';
-const CLIENT_SECRET  = process.env.NEXT_PUBLIC_CLIENT_SECRET ?? '';
-const MASTER_PASSWORD = process.env.NEXT_PUBLIC_MASTER_PASSWORD ?? '';
-
-if (!API_URL || !CLIENT_ID || !CLIENT_SECRET) {
-  // eslint‑disable‑next‑line no-console
-  console.warn('[Vault] Missing env variables – check your .env.local');
-}
-
-export default function Vault() {
-  const [status, setStatus] = useState('');
-  const [vaultData, setVaultData] = useState<any>(null);
-  const [vaultItems, setVaultItems] = useState<DecryptedCipher[] | null>(null);
-  const [errorMsg, setErrorMsg] = useState<string>('');
-
-  /** POST to /api/vault/sync and populate the view */
-  async function fetchVaultData(token: string) {
-    setStatus('Syncing vault…');
-    const res = await fetch('/api/vault/sync', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ apiUrl: API_URL, token }),
-    }).then(r => r.json());
-
-    if (!res.error) {
-      setVaultData(res);
-      if (MASTER_PASSWORD) {
-        try {
-          const items = await decryptVault(res, MASTER_PASSWORD);
-          setVaultItems(items);
-        } catch (e: any) {
-          setErrorMsg(`Decrypt failed: ${e.message}`);
-        }
-      }
-      setStatus('Vault synced');
-    } else {
-      setStatus('Sync failed');
-      setErrorMsg(res.error);
-    }
-  }
-
-  /** Get OAuth token using the client‑credential flow */
-  async function handleLogin() {
-    setStatus('Getting token…');
-    setErrorMsg('');
-
-    const res = await fetch('/api/vault/login', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        url: API_URL,
-        clientId: CLIENT_ID,
-        clientSecret: CLIENT_SECRET,
-      }),
-    }).then(r => r.json());
-
-    if (res.access_token) {
-      setStatus('Token OK – syncing…');
-      await fetchVaultData(res.access_token);
-    } else {
-      setStatus('Login failed');
-      setErrorMsg(res.error ?? 'Unknown error – check the server logs');
-    }
-  }
-
+export default function Vault(){
+  const { setGraph } = useGraph()
   return (
-    <div className="max-w-md mx-auto p-8">
-      <h1 className="text-2xl font-bold mb-6">Vault Sync</h1>
-
-      <button
-        onClick={handleLogin}
-        className="bg-primary hover:bg-primary/80 transition text-white px-4 py-2 rounded w-full"
-      >
-        Login &amp; Sync (env)
-      </button>
-
-      <p className="mt-4 text-sm text-secondary">{status}</p>
-      {errorMsg && (
-        <pre className="mt-2 p-2 bg-red-100 text-red-600 text-xs whitespace-pre-wrap break-all rounded">
-          {errorMsg}
-        </pre>
-      )}
-
-      {vaultData && (
-        <pre className="mt-6 text-xs whitespace-pre-wrap break-all bg-gray-100 p-4 rounded max-h-[60vh] overflow-auto">
-          {JSON.stringify(vaultData, null, 2)}
-        </pre>
-      )}
-
-      {vaultItems && (
-        <pre className="mt-6 text-xs whitespace-pre-wrap break-all bg-green-100 p-4 rounded max-h-[60vh] overflow-auto">
-          {JSON.stringify(vaultItems, null, 2)}
-        </pre>
-      )}
-
-      {MASTER_PASSWORD === '' && (
-        <p className="mt-4 text-xs text-yellow-600">
-          ⚠️ <code>NEXT_PUBLIC_MASTER_PASSWORD</code> not set – you will only see the
-          encrypted blob.
-        </p>
-      )}
+    <div className="p-4 flex flex-col gap-4">
+      <UploadZone onLoad={data=>setGraph(parseVault(data))} />
+      <VaultDiagram />
     </div>
-  );
+  )
 }

--- a/app-main/styles/globals.css
+++ b/app-main/styles/globals.css
@@ -2,42 +2,6 @@
 @tailwind components;
 @tailwind utilities;
 
-
 body {
-    background-color: lightblue;
+  @apply bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100 min-h-screen flex flex-col;
 }
-
-
-@keyframes circle {
-    0% {
-        transform: rotate(0deg) translateX(50px) rotate(0deg);
-    }
-    100% {
-        transform: rotate(360deg) translateX(50px) rotate(-360deg);
-    }
-}
-
-
-
-/* Inside styles/globals.css */
-
-@keyframes customPulse {
-    0% {
-      transform: scale(1);
-    }
-    33% {
-      transform: scale(1.5); /* Expand to 1.5x size */
-    }
-    66% {
-      transform: scale(0.75); /* Shrink to 0.75x size */
-    }
-    100% {
-      transform: scale(1); /* Back to original size */
-    }
-  }
-  
-  /* Custom class for the animation */
-  .animate-custom-pulse {
-    animation: customPulse 0.4s ease-in-out 1; /* 0.8 seconds per cycle, repeat 3 times */
-  }
-  

--- a/app-main/tsconfig.json
+++ b/app-main/tsconfig.json
@@ -18,7 +18,11 @@
     "isolatedModules": true,
     // 👇 Important for Next.js + TS
     "jsx": "preserve",
-    "incremental": true
+    "incremental": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    }
   },
   // 👇 Make sure next-env.d.ts is included
   "include": [


### PR DESCRIPTION
## Summary
- install `reactflow`, `zustand`, `@tanstack/react-query`, `react-dropzone`
- render an interactive vault diagram using React Flow
- store graph data in a zustand store
- persist uploaded vault file to `localStorage`
- hydrate graph state on page load
- restyle global layout

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68414a9f02c4832cb5388c190efa3a08