### PR TITLE
Add vault removal option

### DIFF
--- a/app-main/lib/storage.ts
+++ b/app-main/lib/storage.ts
@@ -8,3 +8,6 @@ export const saveVault = (raw:string)=>{
 export const loadVault = ()=>{
   try{ const raw = localStorage.getItem(KEY); return raw? parseVault(JSON.parse(raw)):null }catch{ return null }
 }
+export const clearVault = ()=>{
+  try{ localStorage.removeItem(KEY) }catch{}
+}

--- a/app-main/pages/vault.tsx
+++ b/app-main/pages/vault.tsx
@@ -1,6 +1,7 @@
 import UploadZone from '@/components/UploadZone'
 import VaultDiagram from '@/components/VaultDiagram'
 import { parseVault } from '@/lib/parseVault'
+import { clearVault } from '@/lib/storage'
 import { useGraph } from '@/contexts/GraphStore'
 
 export default function Vault(){
@@ -9,6 +10,15 @@ export default function Vault(){
     <div className="p-4 flex flex-col gap-4">
       <UploadZone onLoad={data=>setGraph(parseVault(data))} />
       <VaultDiagram />
+      <button
+        onClick={() => {
+          clearVault()
+          setGraph({ nodes: [], edges: [] })
+        }}
+        className="self-start px-4 py-2 bg-red-500 text-white rounded"
+      >
+        Delete Vault Data
+      </button>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- enable clearing saved vault data in local storage
- allow users to delete the vault graph from the vault page

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68415a92b648832c95d393d686e113c6