### PR TITLE
Enable vault editing and export

### DIFF
--- a/app-main/components/ExportButton.tsx
+++ b/app-main/components/ExportButton.tsx
@@ -1,0 +1,29 @@
+'use client'
+import { useVault } from '@/contexts/VaultStore'
+import { saveVault } from '@/lib/storage'
+
+export default function ExportButton() {
+  const { vault } = useVault()
+  if (!vault) return null
+
+  const onExport = () => {
+    const json = JSON.stringify(vault, null, 2)
+    const blob = new Blob([json], { type: 'application/json' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = 'bitwarden-export.json'
+    a.click()
+    URL.revokeObjectURL(url)
+    saveVault(json)
+  }
+
+  return (
+    <button
+      onClick={onExport}
+      className="px-4 py-2 bg-indigo-600 text-white rounded self-start"
+    >
+      Export Vault
+    </button>
+  )
+}

--- a/app-main/components/VaultEditor.tsx
+++ b/app-main/components/VaultEditor.tsx
@@ -1,0 +1,55 @@
+'use client'
+import { useVault } from '@/contexts/VaultStore'
+
+export default function VaultEditor() {
+  const { vault, updateItem } = useVault()
+  if (!vault) return null
+  return (
+    <div className="overflow-x-auto">
+      <table className="min-w-full text-sm border">
+        <thead className="bg-gray-100">
+          <tr>
+            <th className="border px-2 py-1">Name</th>
+            <th className="border px-2 py-1">Username</th>
+            <th className="border px-2 py-1">Password</th>
+            <th className="border px-2 py-1">URI</th>
+          </tr>
+        </thead>
+        <tbody>
+          {vault.items?.map((item: any, idx: number) => (
+            <tr key={item.id} className="odd:bg-gray-50">
+              <td className="border px-2 py-1">
+                <input
+                  className="w-full border px-1"
+                  value={item.name || ''}
+                  onChange={(e) => updateItem(idx, 'name', e.target.value)}
+                />
+              </td>
+              <td className="border px-2 py-1">
+                <input
+                  className="w-full border px-1"
+                  value={item.login?.username || ''}
+                  onChange={(e) => updateItem(idx, 'username', e.target.value)}
+                />
+              </td>
+              <td className="border px-2 py-1">
+                <input
+                  className="w-full border px-1"
+                  value={item.login?.password || ''}
+                  onChange={(e) => updateItem(idx, 'password', e.target.value)}
+                />
+              </td>
+              <td className="border px-2 py-1">
+                <input
+                  className="w-full border px-1"
+                  value={item.login?.uris?.[0]?.uri || ''}
+                  onChange={(e) => updateItem(idx, 'uri', e.target.value)}
+                />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/app-main/contexts/VaultStore.ts
+++ b/app-main/contexts/VaultStore.ts
@@ -1,0 +1,33 @@
+'use client'
+import { create } from 'zustand'
+
+interface VaultState {
+  vault: any | null
+  setVault: (v: any) => void
+  updateItem: (index: number, field: string, value: string) => void
+}
+
+export const useVault = create<VaultState>((set, get) => ({
+  vault: null,
+  setVault: (v) => set({ vault: v }),
+  updateItem: (index, field, value) => {
+    const v = get().vault
+    if (!v || !v.items) return
+    const items = [...v.items]
+    const item = { ...items[index] }
+    if (field === 'name') item.name = value
+    else if (field === 'username')
+      item.login = { ...item.login, username: value }
+    else if (field === 'password')
+      item.login = { ...item.login, password: value }
+    else if (field === 'uri') {
+      const uris = item.login?.uris?.length
+        ? [...item.login.uris]
+        : [{ match: null, uri: '' }]
+      uris[0] = { ...uris[0], uri: value }
+      item.login = { ...item.login, uris }
+    }
+    items[index] = item
+    set({ vault: { ...v, items } })
+  },
+}))

--- a/app-main/lib/storage.ts
+++ b/app-main/lib/storage.ts
@@ -1,10 +1,8 @@
-import { parseVault } from './parseVault'
-
 const KEY = 'vault-data'
 
 export const saveVault = (raw:string)=>{
   try{ localStorage.setItem(KEY, raw) }catch{}
 }
 export const loadVault = ()=>{
-  try{ const raw = localStorage.getItem(KEY); return raw? parseVault(JSON.parse(raw)):null }catch{ return null }
+  try{ const raw = localStorage.getItem(KEY); return raw? JSON.parse(raw):null }catch{ return null }
 }

--- a/app-main/pages/_app.tsx
+++ b/app-main/pages/_app.tsx
@@ -3,13 +3,19 @@ import '../styles/globals.css'
 import type { AppProps } from 'next/app'
 import { useEffect } from 'react'
 import { useGraph } from '@/contexts/GraphStore'
+import { useVault } from '@/contexts/VaultStore'
 import { loadVault } from '@/lib/storage'
+import { parseVault } from '@/lib/parseVault'
 
 export default function App({ Component, pageProps }: AppProps) {
   const { setGraph } = useGraph()
-  useEffect(()=>{
-    const g = loadVault()
-    if(g) setGraph(g)
-  },[setGraph])
+  const { setVault } = useVault()
+  useEffect(() => {
+    const raw = loadVault()
+    if (raw) {
+      setVault(raw)
+      setGraph(parseVault(raw))
+    }
+  }, [setGraph, setVault])
   return <Component {...pageProps} />
 }

--- a/app-main/pages/vault.tsx
+++ b/app-main/pages/vault.tsx
@@ -1,13 +1,31 @@
 import UploadZone from '@/components/UploadZone'
 import VaultDiagram from '@/components/VaultDiagram'
+import VaultEditor from '@/components/VaultEditor'
+import ExportButton from '@/components/ExportButton'
 import { parseVault } from '@/lib/parseVault'
+import { saveVault } from '@/lib/storage'
 import { useGraph } from '@/contexts/GraphStore'
+import { useVault } from '@/contexts/VaultStore'
 
-export default function Vault(){
+export default function Vault() {
   const { setGraph } = useGraph()
+  const { vault, setVault } = useVault()
+
+  const handleLoad = (data: any) => {
+    setVault(data)
+    setGraph(parseVault(data))
+    saveVault(JSON.stringify(data))
+  }
+
   return (
     <div className="p-4 flex flex-col gap-4">
-      <UploadZone onLoad={data=>setGraph(parseVault(data))} />
+      <UploadZone onLoad={handleLoad} />
+      {vault && (
+        <>
+          <VaultEditor />
+          <ExportButton />
+        </>
+      )}
       <VaultDiagram />
     </div>
   )


### PR DESCRIPTION
## Summary
- persist raw vault data in VaultStore using zustand
- add editable table for items
- allow exporting edited vault to JSON
- load saved vault and parse on app start

## Testing
- `npm install`
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68415b20247c832c9411a73165664da9