### PR TITLE
Fix parseVault handling of bare domain URLs

### DIFF
--- a/app-main/lib/parseVault.ts
+++ b/app-main/lib/parseVault.ts
@@ -1,8 +1,16 @@
 import type { Edge, Node } from 'reactflow'
 
 // quick helper ---------------------------------------------------------------
-const domainFrom = (raw: string | undefined) =>
-  raw ? new URL(raw).hostname.replace(/^www\./, '') : undefined
+const domainFrom = (raw: string | undefined) => {
+  if (!raw) return undefined
+  try {
+    return new URL(raw).hostname.replace(/^www\./, '')
+  } catch {
+    // Bitwarden exports may contain bare domains without a scheme.
+    // Skip invalid URLs rather than throwing so imports don't fail.
+    return undefined
+  }
+}
 
 const logoFor = (domain?: string) =>
   domain ? `https://logo.clearbit.com/${domain}` : '/img/default.svg'


### PR DESCRIPTION
## Summary
- handle Bitwarden entries where a login URI may not have a scheme
- allow upload of Bitwarden JSON with bare domains without failing

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68415e14be04832c97cc90da3e341840