### PR TITLE
Fix deprecated image config

### DIFF
--- a/app-main/next.config.js
+++ b/app-main/next.config.js
@@ -1,7 +1,13 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   images: {
-    domains: ['logo.clearbit.com'],
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'logo.clearbit.com',
+        pathname: '/**',
+      },
+    ],
   },
   async rewrites() {
     return [


### PR DESCRIPTION
## Summary
- update `next.config.js` to use `images.remotePatterns`

## Testing
- `npm run build` *(fails: Cannot find name 'clearVault')*

------
https://chatgpt.com/codex/tasks/task_e_68415f07c084832c93e0bea9818163a5