### PR TITLE
Add per-node editing modal

### DIFF
--- a/app-main/components/ItemModal.tsx
+++ b/app-main/components/ItemModal.tsx
@@ -1,0 +1,24 @@
+'use client'
+import { useVault } from '@/contexts/VaultStore'
+
+export default function ItemModal({ index, onClose }:{ index:number, onClose:()=>void }){
+  const { vault, updateItem } = useVault()
+  if(!vault) return null
+  const item = vault.items?.[index]
+  if(!item) return null
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center" onClick={onClose}>
+      <div className="bg-white rounded p-4 w-72" onClick={e=>e.stopPropagation()}>
+        <h2 className="text-lg mb-2">Edit Item</h2>
+        <div className="flex flex-col gap-2">
+          <input className="border px-2 py-1" value={item.name || ''} onChange={e=>updateItem(index,'name',e.target.value)} placeholder="Name" />
+          <input className="border px-2 py-1" value={item.login?.username || ''} onChange={e=>updateItem(index,'username',e.target.value)} placeholder="Username" />
+          <input className="border px-2 py-1" value={item.login?.password || ''} onChange={e=>updateItem(index,'password',e.target.value)} placeholder="Password" />
+          <input className="border px-2 py-1" value={item.login?.uris?.[0]?.uri || ''} onChange={e=>updateItem(index,'uri',e.target.value)} placeholder="URI" />
+          <button className="mt-2 bg-indigo-600 text-white py-1 rounded" onClick={onClose}>Close</button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app-main/components/VaultDiagram.tsx
+++ b/app-main/components/VaultDiagram.tsx
@@ -1,21 +1,40 @@
 'use client'
-import React, { useCallback } from 'react'
+import React, { useCallback, useState, useEffect } from 'react'
 import ReactFlow, {
   Background,
   Controls,
   MiniMap,
   applyNodeChanges,
   NodeChange,
+  Node,
 } from 'reactflow'
 import 'reactflow/dist/style.css'
 
 import { useGraph } from '@/contexts/GraphStore'
+import { useVault } from '@/contexts/VaultStore'
+import ItemModal from './ItemModal'
 import VaultNode from './VaultNode'
 
 const nodeTypes = { vault: VaultNode }
 
 export default function VaultDiagram() {
   const { nodes, edges, setGraph } = useGraph()
+  const { vault } = useVault()
+  const [menu, setMenu] = useState<{x:number,y:number,id:string}|null>(null)
+  const [editIndex, setEditIndex] = useState<number|null>(null)
+
+  const handleEdit = (id: string) => {
+    if(!vault) return
+    const rawId = id.replace(/^item-/, '')
+    const idx = vault.items?.findIndex((i:any)=> String(i.id)===rawId)
+    if(idx!==undefined && idx>-1) setEditIndex(idx)
+  }
+
+  useEffect(()=>{
+    const close = ()=>setMenu(null)
+    document.addEventListener('click', close)
+    return ()=>document.removeEventListener('click', close)
+  },[])
 
   // allow the user to drag nodes and keep the new coordinates in state
   const onNodesChange = useCallback(
@@ -28,18 +47,38 @@ export default function VaultDiagram() {
   )
 
   return (
-    <div className="w-full h-[80vh] rounded-lg overflow-hidden border">
+    <div className="relative w-full h-[80vh] rounded-lg overflow-hidden border">
       <ReactFlow
         nodes={nodes}
         edges={edges}
         nodeTypes={nodeTypes}
         onNodesChange={onNodesChange}
+        onNodeContextMenu={(e:React.MouseEvent, n:Node)=>{
+          e.preventDefault()
+          setMenu({x:e.clientX,y:e.clientY,id:n.id})
+        }}
         fitView
       >
         <Background />
         <MiniMap pannable />
         <Controls />
       </ReactFlow>
+      {menu && (
+        <ul
+          className="absolute bg-white border rounded shadow text-sm"
+          style={{top:menu.y,left:menu.x}}
+        >
+          <li
+            className="px-3 py-1 cursor-pointer hover:bg-gray-100"
+            onClick={()=>{handleEdit(menu.id);setMenu(null)}}
+          >
+            Edit Item
+          </li>
+        </ul>
+      )}
+      {editIndex!==null && (
+        <ItemModal index={editIndex} onClose={()=>setEditIndex(null)} />
+      )}
     </div>
   )
 }

--- a/app-main/lib/parseVault.ts
+++ b/app-main/lib/parseVault.ts
@@ -24,7 +24,11 @@ export const parseVault = (vault: any) => {
       id: itemId,
       type: 'vault', //  <-- custom node
       position: { x: Math.random() * 600, y: Math.random() * 400 },
-      data: { label: item.name, logoUrl: logoFor(dom) },
+      data: {
+        label: item.name,
+        logoUrl: logoFor(dom),
+        username: item.login?.username,
+      },
     })
 
     ;(item.login?.uris || []).forEach((u: any, i: number) => {

--- a/app-main/pages/vault.tsx
+++ b/app-main/pages/vault.tsx
@@ -3,7 +3,7 @@ import VaultDiagram from '@/components/VaultDiagram'
 import VaultEditor from '@/components/VaultEditor'
 import ExportButton from '@/components/ExportButton'
 import { parseVault } from '@/lib/parseVault'
-import { saveVault } from '@/lib/storage'
+import { saveVault, clearVault } from '@/lib/storage'
 import { useGraph } from '@/contexts/GraphStore'
 import { useVault } from '@/contexts/VaultStore'
 


### PR DESCRIPTION
## Summary
- add ItemModal for editing vault items
- include username in parsed node data
- add context menu to VaultDiagram nodes to open ItemModal
- import `clearVault` fix in vault page

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68415f60b584832cbdca8663c389bb6d