### PR TITLE
Hide upload zone after vault upload

### DIFF
--- a/app-main/components/DeleteZone.tsx
+++ b/app-main/components/DeleteZone.tsx
@@ -1,0 +1,26 @@
+'use client'
+import { useGraph } from '@/contexts/GraphStore'
+import { useVault } from '@/contexts/VaultStore'
+import * as storage from '@/lib/storage'
+
+export default function DeleteZone(){
+  const { setGraph } = useGraph()
+  const { setVault } = useVault()
+  const onDelete = () => {
+    if(confirm('Delete uploaded vault data?')){
+      storage.clearVault()
+      setVault(null)
+      setGraph({ nodes: [], edges: [] })
+    }
+  }
+  return (
+    <div className="border-2 border-dashed p-8 text-center">
+      <button
+        onClick={onDelete}
+        className="bg-red-500 text-white px-4 py-2 rounded"
+      >
+        Delete Uploaded Data
+      </button>
+    </div>
+  )
+}

--- a/app-main/pages/vault.tsx
+++ b/app-main/pages/vault.tsx
@@ -1,4 +1,5 @@
 import UploadZone from '@/components/UploadZone'
+import DeleteZone from '@/components/DeleteZone'
 import VaultDiagram from '@/components/VaultDiagram'
 import ExportButton from '@/components/ExportButton'
 import { parseVault } from '@/lib/parseVault'
@@ -18,18 +19,13 @@ export default function Vault() {
 
   return (
     <div className="p-4 flex flex-col gap-4 mx-auto max-w-7xl px-6">
-      <UploadZone onLoad={handleLoad} />
+      {vault ? (
+        <DeleteZone />
+      ) : (
+        <UploadZone onLoad={handleLoad} />
+      )}
       {vault && <ExportButton />}
       <VaultDiagram />
-      <button
-        onClick={() => {
-          storage.clearVault()
-          setGraph({ nodes: [], edges: [] })
-        }}
-        className="self-start px-4 py-2 bg-red-500 text-white rounded"
-      >
-        Delete Vault Data
-      </button>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- add a DeleteZone component for clearing stored vault data
- swap UploadZone for DeleteZone once vault data exists

## Testing
- `npx tsc -p tsconfig.json`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6841675afc80832c904c43566df31a88