### PR TITLE
Fix right-click menu placement

### DIFF
--- a/app-main/components/VaultDiagram.tsx
+++ b/app-main/components/VaultDiagram.tsx
@@ -1,5 +1,5 @@
 'use client'
-import React, { useCallback, useState, useEffect } from 'react'
+import React, { useCallback, useState, useEffect, useRef } from 'react'
 import ReactFlow, {
   Background,
   Controls,
@@ -20,6 +20,7 @@ const nodeTypes = { vault: VaultNode }
 export default function VaultDiagram() {
   const { nodes, edges, setGraph } = useGraph()
   const { vault } = useVault()
+  const diagramRef = useRef<HTMLDivElement>(null)
   const [menu, setMenu] = useState<{x:number,y:number,id:string}|null>(null)
   const [editIndex, setEditIndex] = useState<number|null>(null)
 
@@ -47,15 +48,18 @@ export default function VaultDiagram() {
   )
 
   return (
-    <div className="relative w-full h-[80vh] rounded-lg overflow-hidden border">
+    <div ref={diagramRef} className="relative w-full h-[80vh] rounded-lg overflow-hidden border">
       <ReactFlow
         nodes={nodes}
         edges={edges}
         nodeTypes={nodeTypes}
         onNodesChange={onNodesChange}
-        onNodeContextMenu={(e:React.MouseEvent, n:Node)=>{
+        onNodeContextMenu={(e:React.MouseEvent, n:Node) => {
           e.preventDefault()
-          setMenu({x:e.clientX,y:e.clientY,id:n.id})
+          const rect = diagramRef.current?.getBoundingClientRect()
+          const x = rect ? e.clientX - rect.left : e.clientX
+          const y = rect ? e.clientY - rect.top : e.clientY
+          setMenu({ x, y, id: n.id })
         }}
         fitView
       >


### PR DESCRIPTION
## Summary
- make context menu open relative to the vault diagram

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684167e9c204832cab0919777325cc91