### PR TITLE
Add vault recovery map parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# Upgraded Journey
+
+This repository contains a small Next.js application used to visualize Bitwarden vault data. It can parse a vault export and render items as nodes in a diagram.
+
+## Recovery Relationship Field
+
+Vaultdiagram recognizes a custom Bitwarden field named `vaultdiagram-recovery-map` to describe account recovery relationships. The field value must be valid JSON with optional keys:
+
+- `recovers`: array of item names the current item can recover.
+- `recovered_by`: array of item names that can recover the current item.
+
+Example for an item that recovers two others:
+
+```json
+{"recovers": ["LinkedIn", "Netflix"]}
+```
+
+The recovered items would include the opposite link:
+
+```json
+{"recovered_by": ["Gmail"]}
+```
+
+Keeping the value structured allows the application to automatically create edges between items when parsing the vault.

--- a/app-main/lib/parseVault.ts
+++ b/app-main/lib/parseVault.ts
@@ -15,10 +15,14 @@ export const parseVault = (vault: any) => {
 
   if (!vault?.items) return { nodes, edges }
 
+  const nameToId: Record<string, string> = {}
+
   vault.items.forEach((item: any) => {
     const itemId = `item-${item.id}`
     const firstUri = item.login?.uris?.[0]?.uri
     const dom = domainFrom(firstUri)
+
+    nameToId[item.name] = itemId
 
     nodes.push({
       id: itemId,
@@ -30,6 +34,43 @@ export const parseVault = (vault: any) => {
         username: item.login?.username,
       },
     })
+  })
+
+  const added = new Set<string>()
+
+  vault.items.forEach((item: any) => {
+    const itemId = nameToId[item.name]
+    const field = item.fields?.find((f: any) => f.name === 'vaultdiagram-recovery-map')
+    if (!field || typeof field.value !== 'string') return
+    try {
+      const data = JSON.parse(field.value)
+      if (Array.isArray(data.recovers)) {
+        data.recovers.forEach((t: string) => {
+          const targetId = nameToId[t]
+          if (targetId) {
+            const id = `edge-${itemId}-${targetId}`
+            if (!added.has(id)) {
+              edges.push({ id, source: itemId, target: targetId })
+              added.add(id)
+            }
+          }
+        })
+      }
+      if (Array.isArray(data.recovered_by)) {
+        data.recovered_by.forEach((s: string) => {
+          const sourceId = nameToId[s]
+          if (sourceId) {
+            const id = `edge-${sourceId}-${itemId}`
+            if (!added.has(id)) {
+              edges.push({ id, source: sourceId, target: itemId })
+              added.add(id)
+            }
+          }
+        })
+      }
+    } catch (err) {
+      // ignore parse errors
+    }
   })
 
   return { nodes, edges }


### PR DESCRIPTION
## Summary
- document `vaultdiagram-recovery-map` custom field in new README
- parse `vaultdiagram-recovery-map` data to create recovery edges

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68416c56ad04832c918e758541219d0d