### PR TITLE
Fix domain parsing for vault items

### DIFF
--- a/app-main/lib/parseVault.ts
+++ b/app-main/lib/parseVault.ts
@@ -1,8 +1,18 @@
 import type { Edge, Node } from 'reactflow'
 
 // quick helper ---------------------------------------------------------------
-const domainFrom = (raw: string | undefined) =>
-  raw ? new URL(raw).hostname.replace(/^www\./, '') : undefined
+const domainFrom = (raw: string | undefined) => {
+  if (!raw) return undefined
+  try {
+    return new URL(raw).hostname.replace(/^www\./, '')
+  } catch {
+    try {
+      return new URL(`http://${raw}`).hostname.replace(/^www\./, '')
+    } catch {
+      return undefined
+    }
+  }
+}
 
 const logoFor = (domain?: string) =>
   domain ? `https://logo.clearbit.com/${domain}` : '/img/default.svg'


### PR DESCRIPTION
## Summary
- handle URLs without protocol in `domainFrom` helper

## Testing
- `npm install`
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68416c7f332c832cb9b690207539f5b7