### PR TITLE
Add vault template generation option

### DIFF
--- a/app-main/components/TemplateZone.tsx
+++ b/app-main/components/TemplateZone.tsx
@@ -1,0 +1,19 @@
+'use client'
+import { createTemplate, TemplateName } from '@/lib/sampleVault'
+
+export default function TemplateZone({ onGenerate }:{ onGenerate:(v:any)=>void }){
+  const generate = (name: TemplateName) => {
+    const v = createTemplate(name)
+    onGenerate(v)
+  }
+  return (
+    <div className="border-2 border-dashed p-8 text-center flex flex-col gap-4">
+      <span>Or generate a template:</span>
+      <div className="flex justify-center gap-2">
+        <button onClick={()=>generate('mail')} className="px-3 py-2 bg-indigo-600 text-white rounded">Mail</button>
+        <button onClick={()=>generate('linkedin')} className="px-3 py-2 bg-indigo-600 text-white rounded">LinkedIn</button>
+        <button onClick={()=>generate('netflix')} className="px-3 py-2 bg-indigo-600 text-white rounded">Netflix</button>
+      </div>
+    </div>
+  )
+}

--- a/app-main/lib/sampleVault.ts
+++ b/app-main/lib/sampleVault.ts
@@ -1,0 +1,62 @@
+export type TemplateName = 'mail' | 'linkedin' | 'netflix'
+
+export interface VaultItem {
+  id: string
+  name: string
+  login: {
+    username?: string
+    password?: string
+    uris?: { uri: string; match: null | string }[]
+  }
+}
+
+export interface VaultData {
+  items: VaultItem[]
+}
+
+const templates: Record<TemplateName, VaultData> = {
+  mail: {
+    items: [
+      {
+        id: '1',
+        name: 'Gmail',
+        login: {
+          username: 'john.doe@gmail.com',
+          password: 'SuperSecret123',
+          uris: [{ uri: 'https://mail.google.com', match: null }],
+        },
+      },
+    ],
+  },
+  linkedin: {
+    items: [
+      {
+        id: '2',
+        name: 'LinkedIn',
+        login: {
+          username: 'johndoe',
+          password: 'Pa$$w0rd!',
+          uris: [{ uri: 'https://www.linkedin.com', match: null }],
+        },
+      },
+    ],
+  },
+  netflix: {
+    items: [
+      {
+        id: '3',
+        name: 'Netflix',
+        login: {
+          username: 'john@doe.com',
+          password: 'password123',
+          uris: [{ uri: 'https://www.netflix.com', match: null }],
+        },
+      },
+    ],
+  },
+}
+
+export function createTemplate(name: TemplateName): VaultData {
+  // deep clone to avoid accidental mutations
+  return JSON.parse(JSON.stringify(templates[name]))
+}

--- a/app-main/pages/vault.tsx
+++ b/app-main/pages/vault.tsx
@@ -2,6 +2,7 @@ import UploadZone from '@/components/UploadZone'
 import DeleteZone from '@/components/DeleteZone'
 import VaultDiagram from '@/components/VaultDiagram'
 import ExportButton from '@/components/ExportButton'
+import TemplateZone from '@/components/TemplateZone'
 import { parseVault } from '@/lib/parseVault'
 import * as storage from '@/lib/storage'
 import { useGraph } from '@/contexts/GraphStore'
@@ -22,7 +23,10 @@ export default function Vault() {
       {vault ? (
         <DeleteZone />
       ) : (
-        <UploadZone onLoad={handleLoad} />
+        <>
+          <UploadZone onLoad={handleLoad} />
+          <TemplateZone onGenerate={handleLoad} />
+        </>
       )}
       {vault && <ExportButton />}
       <VaultDiagram />


### PR DESCRIPTION
## Summary
- allow generating a dummy vault instead of uploading
- offer Mail, LinkedIn and Netflix templates
- parse generated template like uploaded vault data

## Testing
- `npm --version`
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68416d471cc8832cb22d0e1c97941ad5