### PR TITLE
Remove default templates from sample vault

### DIFF
--- a/app-main/components/TemplateZone.tsx
+++ b/app-main/components/TemplateZone.tsx
@@ -10,10 +10,7 @@ export default function TemplateZone({ onGenerate }:{ onGenerate:(v:any)=>void }
     <div className="border-2 border-dashed p-8 text-center flex flex-col gap-4">
       <span>Or generate a template:</span>
       <div className="flex justify-center gap-2">
-        <button onClick={()=>generate('mail')} className="px-3 py-2 bg-indigo-600 text-white rounded">Mail</button>
-        <button onClick={()=>generate('linkedin')} className="px-3 py-2 bg-indigo-600 text-white rounded">LinkedIn</button>
-        <button onClick={()=>generate('netflix')} className="px-3 py-2 bg-indigo-600 text-white rounded">Netflix</button>
-        <button onClick={()=>generate('demo')} className="px-3 py-2 bg-indigo-600 text-white rounded">Demo</button>
+        <button onClick={() => generate('demo')} className="px-3 py-2 bg-indigo-600 text-white rounded">Demo</button>
       </div>
     </div>
   )

--- a/app-main/lib/sampleVault.ts
+++ b/app-main/lib/sampleVault.ts
@@ -1,5 +1,5 @@
 
-export type TemplateName = 'mail' | 'linkedin' | 'netflix' | 'demo'
+export type TemplateName = 'demo'
 
 export interface VaultItem {
   id: string
@@ -16,46 +16,6 @@ export interface VaultData {
 }
 
 const templates: Record<TemplateName, VaultData> = {
-  mail: {
-    items: [
-      {
-        id: '1',
-        name: 'Gmail',
-        login: {
-          username: 'john.doe@gmail.com',
-          password: 'SuperSecret123',
-          uris: [{ uri: 'https://mail.google.com', match: null }],
-        },
-      },
-    ],
-  },
-  linkedin: {
-    items: [
-      {
-        id: '2',
-        name: 'LinkedIn',
-        login: {
-          username: 'johndoe',
-          password: 'Pa$$w0rd!',
-          uris: [{ uri: 'https://www.linkedin.com', match: null }],
-        },
-      },
-    ],
-  },
-  netflix: {
-    items: [
-      {
-        id: '3',
-        name: 'Netflix',
-        login: {
-          username: 'john@doe.com',
-          password: 'password123',
-          uris: [{ uri: 'https://www.netflix.com', match: null }],
-        },
-        fields: [{ name: 'recovery', value: 'af4a6fe3-9213-4b0f-8d83-0bf5cf251863', type: 0 }],
-      },
-    ],
-  },
   demo: {
     items: [
       {


### PR DESCRIPTION
## Summary
- remove unused template buttons in `TemplateZone`
- simplify template union to only `'demo'`
- delete `mail`, `linkedin`, and `netflix` templates

## Testing
- `npm test` *(fails: missing `package.json`)*
- `npm test` in `app-main` *(fails: missing script)*
- `npm run build` in `app-main` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68417202d7b8832c992d73243c1144e3