### PR TITLE
Improve vault node positioning

### DIFF
--- a/app-main/lib/parseVault.ts
+++ b/app-main/lib/parseVault.ts
@@ -25,20 +25,44 @@ export const parseVault = (vault: any) => {
 
   if (!vault?.items) return { nodes, edges }
 
+  const { width, height } = (() => {
+    if (typeof window === 'undefined') return { width: 600, height: 400 }
+    return { width: window.innerWidth, height: window.innerHeight * 0.8 }
+  })()
+
+  const margin = 40
+  const stepX = 170
+  const stepY = 140
+  const perRow = Math.max(1, Math.floor((width - margin * 2) / stepX))
+  let col = 0
+  let row = 0
+
   const nameToId: Record<string, string> = {}
 
   vault.items.forEach((item: any) => {
     const itemId = `item-${item.id}`
     const firstUri = item.login?.uris?.[0]?.uri
     const dom = domainFrom(firstUri)
-    const isRecovery = item.fields?.some((f:any)=>f.name==='recovery_node' && String(f.value).toLowerCase()==='true')
+    const isRecovery = item.fields?.some(
+      (f: any) =>
+        f.name === 'recovery_node' &&
+        String(f.value).toLowerCase() === 'true'
+    )
 
     nameToId[item.name] = itemId
+
+    const x = margin + col * stepX
+    const y = margin + row * stepY
+    col++
+    if (col >= perRow) {
+      col = 0
+      row++
+    }
 
     nodes.push({
       id: itemId,
       type: 'vault', //  <-- custom node
-      position: { x: Math.random() * 600, y: Math.random() * 400 },
+      position: { x, y },
       data: {
         label: item.name,
         logoUrl: logoFor(dom),
@@ -62,6 +86,21 @@ export const parseVault = (vault: any) => {
         })
       }
     })
+  })
+
+  const nodeMap: Record<string, Node> = {}
+  nodes.forEach(n => (nodeMap[n.id] = n))
+
+  nodes.forEach(n => {
+    if (!n.data?.isRecovery) return
+    const related = edges.filter(e => e.target === n.id)
+    if (!related.length) return
+    const xs = related.map(e => nodeMap[e.source]?.position.x || 0)
+    const ys = related.map(e => nodeMap[e.source]?.position.y || 0)
+    const avgX = xs.reduce((a, b) => a + b, 0) / xs.length
+    const minY = Math.min(...ys)
+    n.position.x = avgX
+    n.position.y = minY - stepY
   })
 
   return { nodes, edges }


### PR DESCRIPTION
## Summary
- keep nodes within the diagram width using a simple grid layout
- place recovery nodes above the items they can recover

## Testing
- `npm install`
- `npm run build` *(fails: sampleVault has TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_6841724e4af4832ca20eaa7ca51a7402