### PR TITLE
Fix icon loading in sample vault

### DIFF
--- a/app-main/lib/parseVault.ts
+++ b/app-main/lib/parseVault.ts
@@ -15,7 +15,7 @@ const domainFrom = (raw: string | undefined) => {
 }
 
 const logoFor = (domain?: string) =>
-  domain ? `https://logo.clearbit.com/${domain}` : '/img/default.svg'
+  domain ? `https://logo.clearbit.com/${domain}?size=80` : '/img/default.svg'
 
 // ---------------------------------------------------------------------------
 // Nothing else changes – we just add `type`, `logoUrl` and a random position.

--- a/app-main/lib/sampleVault.ts
+++ b/app-main/lib/sampleVault.ts
@@ -93,7 +93,7 @@ const templates: Record<TemplateName, VaultData> = {
         login: {
           username: 'victor@reipur.dk',
           password: 'Disarray8-Unified-Abdomen',
-          uris: [{ uri: 'vault.reipur.dk', match: null }],
+          uris: [{ uri: 'https://vault.reipur.dk', match: null }],
         },
         fields: [
           { name: 'recovery', value: 'af4a6fe3-9213-4b0f-8d83-0bf5cf251863', type: 0 },


### PR DESCRIPTION
## Summary
- fetch Clearbit icons in a consistent size
- use https URL for Vaultwarden Dev entry

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684178c3e198832c8dea64a94be367a3