### PR TITLE
Add drag-to-connect recovery method feature

### DIFF
--- a/app-main/components/VaultDiagram.tsx
+++ b/app-main/components/VaultDiagram.tsx
@@ -7,6 +7,7 @@ import ReactFlow, {
   applyNodeChanges,
   NodeChange,
   Node,
+  Connection,
 } from 'reactflow'
 import 'reactflow/dist/style.css'
 
@@ -18,8 +19,8 @@ import VaultNode from './VaultNode'
 const nodeTypes = { vault: VaultNode }
 
 export default function VaultDiagram() {
-  const { nodes, edges, setGraph } = useGraph()
-  const { vault } = useVault()
+  const { nodes, edges, setGraph, addEdge } = useGraph()
+  const { vault, addRecovery } = useVault()
   const diagramRef = useRef<HTMLDivElement>(null)
   const [menu, setMenu] = useState<{x:number,y:number,id:string}|null>(null)
   const [editIndex, setEditIndex] = useState<number|null>(null)
@@ -47,12 +48,24 @@ export default function VaultDiagram() {
     [setGraph, nodes, edges]
   )
 
+  const onConnect = useCallback(
+    (connection: Connection) => {
+      if (!connection.source || !connection.target) return
+      const id = `edge-${connection.source}-${connection.target}`
+      if (edges.some((e) => e.id === id)) return
+      addEdge({ id, source: connection.source, target: connection.target, style: { stroke: '#8b5cf6' } })
+      addRecovery(connection.source.replace(/^item-/, ''), connection.target.replace(/^item-/, ''))
+    },
+    [edges, addEdge, addRecovery],
+  )
+
   return (
     <div ref={diagramRef} className="relative w-full h-[80vh] rounded-lg overflow-hidden border">
       <ReactFlow
         nodes={nodes}
         edges={edges}
         nodeTypes={nodeTypes}
+        onConnect={onConnect}
         onNodesChange={onNodesChange}
         onNodeContextMenu={(e:React.MouseEvent, n:Node) => {
           e.preventDefault()

--- a/app-main/contexts/GraphStore.ts
+++ b/app-main/contexts/GraphStore.ts
@@ -6,11 +6,13 @@ import { VaultGraph } from '@/lib/parseVault'
 interface GraphState {
   nodes: Node[]
   edges: Edge[]
-  setGraph: (g: VaultGraph)=>void
+  setGraph: (g: VaultGraph) => void
+  addEdge: (e: Edge) => void
 }
 
-export const useGraph = create<GraphState>(set=>({
+export const useGraph = create<GraphState>(set => ({
   nodes: [],
   edges: [],
   setGraph: g => set(g),
+  addEdge: e => set(state => ({ edges: [...state.edges, e] })),
 }))


### PR DESCRIPTION
## Summary
- support adding edges in graph store
- keep recovery relationships in vault store
- allow connecting services via drag and drop

## Testing
- `npm --prefix app-main install`
- `npm --prefix app-main run build`

------
https://chatgpt.com/codex/tasks/task_e_68417c7ee5d8832c888fd72e6d32bcd5