### PR TITLE
Add recovery method flag and restrict connections

### DIFF
--- a/app-main/components/EditItemModal.tsx
+++ b/app-main/components/EditItemModal.tsx
@@ -16,7 +16,20 @@ export default function EditItemModal({ index, onClose }: Props) {
   const [showTotp, setShowTotp] = useState(false)
   const [newFieldType, setNewFieldType] = useState('0')
 
-  const updateItemState = (partial: any) => setItem((prev: any) => ({ ...prev, ...partial }))
+  const updateItemState = (partial: any) =>
+    setItem((prev: any) => ({ ...prev, ...partial }))
+
+  const isRecovery = item.fields?.some(
+    (f: any) => f.name === 'recovery_node' && String(f.value).toLowerCase() === 'true'
+  )
+
+  const toggleRecovery = () => {
+    const fields = [...(item.fields || [])]
+    const idx = fields.findIndex((f) => f.name === 'recovery_node')
+    if (idx > -1) fields.splice(idx, 1)
+    else fields.push({ name: 'recovery_node', value: 'true', type: 0 })
+    updateItemState({ fields })
+  }
 
   const handleSave = () => {
     const items = [...vault.items]
@@ -174,6 +187,18 @@ export default function EditItemModal({ index, onClose }: Props) {
               className="w-full border border-gray-300 rounded-md px-3 py-2"
               rows={4}
             />
+          </div>
+          <div className="flex items-center gap-2">
+            <input
+              id="recovery-method"
+              type="checkbox"
+              checked={isRecovery}
+              onChange={toggleRecovery}
+              className="h-4 w-4"
+            />
+            <label htmlFor="recovery-method" className="text-sm">
+              Recovery Method
+            </label>
           </div>
           <div>
             <label className="block text-sm font-medium mb-2">Custom Fields</label>

--- a/app-main/components/VaultDiagram.tsx
+++ b/app-main/components/VaultDiagram.tsx
@@ -5,8 +5,10 @@ import ReactFlow, {
   Controls,
   MiniMap,
   applyNodeChanges,
+  addEdge,
   NodeChange,
   Node,
+  Connection,
 } from 'reactflow'
 import 'reactflow/dist/style.css'
 
@@ -47,6 +49,18 @@ export default function VaultDiagram() {
     [setGraph, nodes, edges]
   )
 
+  const onConnect = useCallback(
+    (conn: Connection) => {
+      const targetNode = nodes.find(n => n.id === conn.target)
+      if (!targetNode?.data?.isRecovery) {
+        alert('Only recovery methods can be targets')
+        return
+      }
+      setGraph({ nodes, edges: addEdge({ ...conn, style: { stroke: '#8b5cf6' } }, edges) })
+    },
+    [nodes, edges, setGraph]
+  )
+
   return (
     <div ref={diagramRef} className="relative w-full h-[80vh] rounded-lg overflow-hidden border">
       <ReactFlow
@@ -54,6 +68,7 @@ export default function VaultDiagram() {
         edges={edges}
         nodeTypes={nodeTypes}
         onNodesChange={onNodesChange}
+        onConnect={onConnect}
         onNodeContextMenu={(e:React.MouseEvent, n:Node) => {
           e.preventDefault()
           const rect = diagramRef.current?.getBoundingClientRect()

--- a/app-main/components/VaultNode.tsx
+++ b/app-main/components/VaultNode.tsx
@@ -24,7 +24,11 @@ export default function VaultNode({ data }: NodeProps) {
       )}
 
       {/* handles */}
-      <Handle type="target" position={Position.Top} />
+      <Handle
+        type="target"
+        position={Position.Top}
+        isValidConnection={() => data.isRecovery}
+      />
       <Handle type="source" position={Position.Bottom} />
     </div>
   )


### PR DESCRIPTION
## Summary
- allow connecting to nodes only if they are marked as recovery nodes
- show a recovery method checkbox in Edit Item modal

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68417cf872e8832c8259f9e878f40892