### PR TITLE
Fix recovery mapping direction

### DIFF
--- a/app-main/contexts/VaultStore.ts
+++ b/app-main/contexts/VaultStore.ts
@@ -65,8 +65,11 @@ export const useVault = create<VaultState>((set, get) => ({
       field.value = JSON.stringify(map)
     }
 
-    updateMap(src, 'recovers', slugTgt)
-    updateMap(tgt, 'recovered_by', slugSrc)
+    // when connecting from a service to a recovery item we
+    // store the relation as target.recovers -> source and
+    // source.recovered_by -> target
+    updateMap(tgt, 'recovers', slugSrc)
+    updateMap(src, 'recovered_by', slugTgt)
 
     items[srcIdx] = src
     items[tgtIdx] = tgt


### PR DESCRIPTION
## Summary
- ensure dragging from a service item to a recovery item saves in the right direction

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68418bc49d04832ca4476fb9c5fbf388