### PR TITLE
Add scalable 2FA mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@ vault is exported and re‑imported:
 * `vaultdiagram-recovery-map` &ndash; JSON describing recovery relationships using
   the above identifiers.
 
+In addition services can reference their two-factor authentication methods with
+the optional `vaultdiagram-2fa-map` field. The value is JSON structured much
+like the recovery map and defaults to an empty object (`{}`) when omitted.
+
+```json
+{"providers": ["gmail-1863", "sms-9604"]}
+```
+
 The JSON object may contain the optional keys:
 
 * `recovers` – array of `vaultdiagram-id` values that this item can recover.

--- a/app-main/components/VaultNode.tsx
+++ b/app-main/components/VaultNode.tsx
@@ -34,6 +34,9 @@ export default function VaultNode({ data }: NodeProps) {
       {data.isRecovery && (
         <span className="text-xs font-semibold text-purple-600">Recovery Node</span>
       )}
+      {!data.isRecovery && data.has2fa && (
+        <span className="text-xs font-semibold text-sky-600">2FA Enabled</span>
+      )}
 
       {/* handles */}
       <Handle

--- a/app-main/lib/parseVault.ts
+++ b/app-main/lib/parseVault.ts
@@ -66,6 +66,16 @@ export const parseVault = (vault: any) => {
         f.name === 'recovery_node' && String(f.value).toLowerCase() === 'true',
     )
 
+    const twofaField = item.fields?.find((f: any) => f.name === 'vaultdiagram-2fa-map')?.value
+    let twofaProviders: string[] = []
+    if (twofaField) {
+      try {
+        const map = JSON.parse(twofaField)
+        twofaProviders = Array.isArray(map.providers) ? map.providers : []
+      } catch {}
+    }
+    const has2fa = twofaProviders.length > 0
+
     const slug = item.fields?.find((f: any) => f.name === 'vaultdiagram-id')?.value
     if (slug) slugToId[slug] = itemId
 
@@ -87,6 +97,7 @@ export const parseVault = (vault: any) => {
         nestedLogoUrl,
         username: item.login?.username,
         isRecovery,
+        has2fa,
       },
     })
   })
@@ -130,6 +141,19 @@ export const parseVault = (vault: any) => {
       if (src)
         edges.push({ id: `edge-${src}-${source}`, source: src, target: source, style: { stroke: '#8b5cf6' } })
     })
+
+    const twofaField = item.fields?.find((f: any) => f.name === 'vaultdiagram-2fa-map')?.value
+    if (twofaField) {
+      try {
+        const map2fa = JSON.parse(twofaField)
+        const providers: string[] = Array.isArray(map2fa.providers) ? map2fa.providers : []
+        providers.forEach((slug: string) => {
+          const src = slugToId[slug]
+          if (src)
+            edges.push({ id: `edge-2fa-${src}-${source}`, source: src, target: source, style: { stroke: '#0ea5e9', strokeDasharray: '4 2' } })
+        })
+      } catch {}
+    }
   })
 
   // -------------------------------------------------------------------------

--- a/app-main/lib/sampleVault.ts
+++ b/app-main/lib/sampleVault.ts
@@ -33,6 +33,7 @@ const templates: Record<TemplateName, VaultData> = {
         fields: [
           { name: 'vaultdiagram-id', value: 'facebook-c3fb', type: 0 },
           { name: 'vaultdiagram-recovery-map', value: '{"recovered_by":["gmail-1863"]}', type: 0 },
+          { name: 'vaultdiagram-2fa-map', value: '{"providers":["sms-9604"]}', type: 0 },
         ],
       },
       {
@@ -62,6 +63,7 @@ const templates: Record<TemplateName, VaultData> = {
         fields: [
           { name: 'vaultdiagram-id', value: 'linkedin-7845', type: 0 },
           { name: 'vaultdiagram-recovery-map', value: '{"recovered_by":["gmail-1863"]}', type: 0 },
+          { name: 'vaultdiagram-2fa-map', value: '{"providers":["sms-9604","gmail-1863","phone-pixel-7a-2b11"]}', type: 0 },
         ],
       },
       {


### PR DESCRIPTION
## Summary
- document `vaultdiagram-2fa-map` field
- show an indicator when an item has 2FA
- parse `vaultdiagram-2fa-map` into nodes and edges
- update sample demo data with 2FA relationships

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68418c5ca3c4832c898c3b4c059f1d85