### PR TITLE
Add typing indicator animation

### DIFF
--- a/app-main/components/ChatInterface.tsx
+++ b/app-main/components/ChatInterface.tsx
@@ -24,6 +24,7 @@ export default function ChatInterface() {
   const [model, setModel]     = useState<(typeof MODELS)[number]>('gpt-3.5-turbo')
   const [input, setInput]     = useState('')
   const [messages, setMessages] = useState<Message[]>([])
+  const [isTyping, setIsTyping] = useState(false)
 
   // ---------------------------------------------------------------------------
   // 🔄  Load stored API‑key / model on mount
@@ -70,6 +71,7 @@ export default function ChatInterface() {
     const history = [...messages, userMsg]
     setMessages(history)
     setInput('')
+    setIsTyping(true)
 
     try {
       const res = await fetch('https://api.openai.com/v1/chat/completions', {
@@ -85,6 +87,8 @@ export default function ChatInterface() {
       if (reply) setMessages((m) => [...m, { role: 'assistant', content: reply }])
     } catch (err) {
       console.error(err)
+    } finally {
+      setIsTyping(false)
     }
   }
 
@@ -159,6 +163,17 @@ export default function ChatInterface() {
             </div>
           </div>
         ))}
+        {isTyping && (
+          <div className="text-left">
+            <div className="inline-block bg-gray-200 dark:bg-gray-700 px-2 py-1 rounded">
+              <div className="typing-indicator">
+                <span className="dot"></span>
+                <span className="dot"></span>
+                <span className="dot"></span>
+              </div>
+            </div>
+          </div>
+        )}
       </div>
 
       <div className="flex gap-2">

--- a/app-main/styles/globals.css
+++ b/app-main/styles/globals.css
@@ -5,3 +5,30 @@
 body {
   @apply bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100 min-h-screen flex flex-col;
 }
+
+.typing-indicator {
+  display: flex;
+  gap: 0.25rem;
+}
+
+.typing-indicator .dot {
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 9999px;
+  background-color: #9ca3af; /* gray-400 */
+  animation: typing 1.2s infinite;
+}
+
+.typing-indicator .dot:nth-child(2) {
+  animation-delay: 0.2s;
+}
+
+.typing-indicator .dot:nth-child(3) {
+  animation-delay: 0.4s;
+}
+
+@keyframes typing {
+  0% { opacity: 0.2; }
+  20% { opacity: 1; }
+  100% { opacity: 0.2; }
+}


### PR DESCRIPTION
## Summary
- add `isTyping` state in ChatInterface
- show typing animation bubble when waiting for a response
- style typing indicator in global CSS

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684190e0f628832ca3c6d7daeb1073f8