### PR TITLE
Add lockable diagram with persistent positions

### DIFF
--- a/app-main/components/VaultDiagram.tsx
+++ b/app-main/components/VaultDiagram.tsx
@@ -15,6 +15,7 @@ import 'reactflow/dist/style.css'
 import { useGraph } from '@/contexts/GraphStore'
 import { useVault } from '@/contexts/VaultStore'
 import { parseVault } from '@/lib/parseVault'
+import * as storage from '@/lib/storage'
 import EditItemModal from './EditItemModal'
 import VaultNode from './VaultNode'
 
@@ -26,6 +27,12 @@ export default function VaultDiagram() {
   const diagramRef = useRef<HTMLDivElement>(null)
   const [menu, setMenu] = useState<{x:number,y:number,id:string}|null>(null)
   const [editIndex, setEditIndex] = useState<number|null>(null)
+  const [locked, setLocked] = useState(true)
+  const positionsRef = useRef<Record<string,{x:number,y:number}>>(storage.loadPositions())
+
+  useEffect(() => {
+    positionsRef.current = storage.loadPositions()
+  }, [vault])
 
   const handleEdit = (id: string) => {
     if(!vault) return
@@ -42,12 +49,21 @@ export default function VaultDiagram() {
 
   // allow the user to drag nodes and keep the new coordinates in state
   const onNodesChange = useCallback(
-    (changes: NodeChange[]) =>
-      setGraph({
-        nodes: applyNodeChanges(changes, nodes),
-        edges,
-      }),
-    [setGraph, nodes, edges]
+    (changes: NodeChange[]) => {
+      const updated = applyNodeChanges(changes, nodes)
+      if(!locked){
+        const map = { ...positionsRef.current }
+        changes.forEach(c=>{
+          if(c.type==='position' && (c as any).position){
+            map[c.id] = (c as any).position
+          }
+        })
+        positionsRef.current = map
+        storage.savePositions(map)
+      }
+      setGraph({ nodes: updated, edges })
+    },
+    [setGraph, nodes, edges, locked]
   )
 
   const onConnect = useCallback(
@@ -74,19 +90,25 @@ export default function VaultDiagram() {
 
   return (
     <div ref={diagramRef} className="relative w-full h-[80vh] rounded-lg overflow-hidden border">
+      <button
+        onClick={() => setLocked(l => !l)}
+        className="absolute top-2 right-2 z-10 bg-white border rounded px-2 py-1 text-sm"
+      >
+        {locked ? 'Unlock' : 'Lock'}
+      </button>
       <ReactFlow
         nodes={nodes}
         edges={edges}
         nodeTypes={nodeTypes}
         onConnect={onConnect}
         onNodesChange={onNodesChange}
-        onNodeContextMenu={(e:React.MouseEvent, n:Node) => {
-          e.preventDefault()
+        onNodeClick={(e:React.MouseEvent, n:Node) => {
           const rect = diagramRef.current?.getBoundingClientRect()
           const x = rect ? e.clientX - rect.left : e.clientX
           const y = rect ? e.clientY - rect.top : e.clientY
           setMenu({ x, y, id: n.id })
         }}
+        nodesDraggable={!locked}
         fitView
       >
         <Background />

--- a/app-main/lib/parseVault.ts
+++ b/app-main/lib/parseVault.ts
@@ -1,4 +1,5 @@
 import type { Edge, Node } from 'reactflow'
+import { loadPositions } from './storage'
 
 // ---------------------------------------------------------------------------
 // Helper utilities
@@ -181,6 +182,15 @@ export const parseVault = (vault: any) => {
       n.position.y = minY - stepY
     })
   }
+
+  // -----------------------------------------------------------------------
+  // Apply saved positions from local storage if available
+  // -----------------------------------------------------------------------
+  const saved = loadPositions()
+  nodes.forEach(n => {
+    const pos = saved[n.id]
+    if(pos) n.position = pos
+  })
 
   return { nodes, edges }
 }

--- a/app-main/lib/storage.ts
+++ b/app-main/lib/storage.ts
@@ -1,4 +1,5 @@
 const KEY = 'vault-data'
+const POS_KEY = 'vault-positions'
 
 export const saveVault = (raw:string)=>{
   try{ localStorage.setItem(KEY, raw) }catch{}
@@ -8,4 +9,14 @@ export const loadVault = ()=>{
 }
 export const clearVault = ()=>{
   try{ localStorage.removeItem(KEY) }catch{}
+}
+
+export const savePositions = (map:Record<string,{x:number,y:number}>)=>{
+  try{ localStorage.setItem(POS_KEY, JSON.stringify(map)) }catch{}
+}
+export const loadPositions = ()=>{
+  try{ const raw = localStorage.getItem(POS_KEY); return raw? JSON.parse(raw):{} }catch{ return {} }
+}
+export const clearPositions = ()=>{
+  try{ localStorage.removeItem(POS_KEY) }catch{}
 }


### PR DESCRIPTION
## Summary
- allow toggling node dragging and remember positions via local storage
- left-click on nodes now opens their context menu
- persist node positions in storage

## Testing
- `npx tsc -p tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_68419367aab8832c9f375825d7f7af1d