### PR TITLE
Add alpha banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,5 @@ Keeping the value structured allows the application to automatically create edge
 
 After installing dependencies with `npm install`, start the development server with `npm run dev`.
 Open the vault page and you will see a chat panel next to the diagram. Enter your OpenAI API key and select a model from the drop-down to enable chatting with ChatGPT. The key and model are saved in your browser's local storage.
+
+The app is currently in an alpha stage. A small red **ALPHA** banner appears in the top-right corner of every page as a reminder.

--- a/app-main/components/AlphaBanner.tsx
+++ b/app-main/components/AlphaBanner.tsx
@@ -1,0 +1,9 @@
+'use client'
+
+export default function AlphaBanner() {
+  return (
+    <div className="fixed top-0 right-0 m-2 bg-red-600 text-white px-3 py-1 rounded-bl-lg text-xs font-semibold z-50 pointer-events-none shadow">
+      ALPHA
+    </div>
+  )
+}

--- a/app-main/pages/_app.tsx
+++ b/app-main/pages/_app.tsx
@@ -6,6 +6,7 @@ import { useGraph } from '@/contexts/GraphStore'
 import { useVault } from '@/contexts/VaultStore'
 import { loadVault } from '@/lib/storage'
 import { parseVault } from '@/lib/parseVault'
+import AlphaBanner from '@/components/AlphaBanner'
 
 export default function App({ Component, pageProps }: AppProps) {
   const { setGraph } = useGraph()
@@ -17,5 +18,10 @@ export default function App({ Component, pageProps }: AppProps) {
       setGraph(parseVault(raw))
     }
   }, [setGraph, setVault])
-  return <Component {...pageProps} />
+  return (
+    <>
+      <AlphaBanner />
+      <Component {...pageProps} />
+    </>
+  )
 }


### PR DESCRIPTION
## Summary
- add `AlphaBanner` component with fixed top-right style
- show the banner on every page via `_app.tsx`
- document the alpha banner in `README.md`

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6841971fd12c832cad7c0d04a83add05