### PR TITLE
Add sidebar close icons

### DIFF
--- a/app-main/components/ChatInterface.tsx
+++ b/app-main/components/ChatInterface.tsx
@@ -1,5 +1,6 @@
 'use client'
 import { useEffect, useState } from 'react'
+import { XMarkIcon } from '@heroicons/react/24/solid'
 
 interface Message {
   role: 'user' | 'assistant'
@@ -19,7 +20,9 @@ const PRICE_LABELS: Record<(typeof MODELS)[number], { label: string; color: stri
   'gpt-4-turbo':    { label: 'cheaplest', color: 'text-red-600'   }, // ⇠ most expensive
 }
 
-export default function ChatInterface() {
+type Props = { onClose?: () => void }
+
+export default function ChatInterface({ onClose }: Props) {
   const [apiKey, setApiKey]   = useState('')
   const [model, setModel]     = useState<(typeof MODELS)[number]>('gpt-3.5-turbo')
   const [input, setInput]     = useState('')
@@ -150,7 +153,12 @@ export default function ChatInterface() {
       {/* Header with Delete‑key action */}
       <div className="flex justify-between items-center mb-1">
         <span className="font-medium">API Key saved</span>
-        <button onClick={deleteKey} className="text-red-600 text-sm underline">Delete Key</button>
+        <div className="flex items-center gap-2">
+          <button onClick={deleteKey} className="text-red-600 text-sm underline">Delete Key</button>
+          {onClose && (
+            <XMarkIcon onClick={onClose} className="h-5 w-5 cursor-pointer" />
+          )}
+        </div>
       </div>
 
       {ModelSelect}

--- a/app-main/components/VaultItemList.tsx
+++ b/app-main/components/VaultItemList.tsx
@@ -1,9 +1,9 @@
 'use client'
 import { useState } from 'react'
 import { useVault } from '@/contexts/VaultStore'
-import { EllipsisVerticalIcon } from '@heroicons/react/24/solid'
+import { EllipsisVerticalIcon, XMarkIcon } from '@heroicons/react/24/solid'
 
-type Props = { onEdit: (index: number) => void }
+type Props = { onEdit: (index: number) => void; onClose?: () => void }
 
 const domainFrom = (raw?: string) => {
   if (!raw) return undefined
@@ -18,7 +18,7 @@ const domainFrom = (raw?: string) => {
   }
 }
 
-export default function VaultItemList({ onEdit }: Props) {
+export default function VaultItemList({ onEdit, onClose }: Props) {
   const { vault } = useVault()
   const [selected, setSelected] = useState<number[]>([])
 
@@ -40,6 +40,11 @@ export default function VaultItemList({ onEdit }: Props) {
 
   return (
     <div className="border rounded w-full md:w-80 overflow-auto max-h-[80vh]">
+      <div className="flex justify-end p-1">
+        {onClose && (
+          <XMarkIcon onClick={onClose} className="h-5 w-5 cursor-pointer" />
+        )}
+      </div>
       <table className="w-full table-auto border-separate border-spacing-y-1">
         <thead className="text-sm text-gray-500 sticky top-0 bg-white">
           <tr>

--- a/app-main/pages/vault.tsx
+++ b/app-main/pages/vault.tsx
@@ -16,6 +16,8 @@ export default function Vault() {
   const { setGraph } = useGraph()
   const { vault, setVault } = useVault()
   const [editIndex, setEditIndex] = useState<number | null>(null)
+  const [showList, setShowList] = useState(true)
+  const [showChat, setShowChat] = useState(true)
 
   const handleLoad = (data: any) => {
     setVault(data)
@@ -35,11 +37,14 @@ export default function Vault() {
       )}
       {vault && <ExportButton />}
       <div className="flex flex-col md:flex-row gap-4">
-        {vault && (
-          <VaultItemList onEdit={(i) => setEditIndex(i)} />
+        {vault && showList && (
+          <VaultItemList
+            onEdit={(i) => setEditIndex(i)}
+            onClose={() => setShowList(false)}
+          />
         )}
         <VaultDiagram />
-        <ChatInterface />
+        {showChat && <ChatInterface onClose={() => setShowChat(false)} />}
       </div>
       {editIndex !== null && (
         <EditItemModal index={editIndex} onClose={() => setEditIndex(null)} />


### PR DESCRIPTION
## Summary
- add optional close icons to ChatInterface and VaultItemList
- allow hiding sidebars from the Vault page

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68419997301c832cbebcde160451950c