### PR TITLE
Add version history feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,7 @@ To enable Google Analytics, copy `app-main/.env.local.example` to `app-main/.env
 
 The app is currently in an alpha stage. A small red **ALPHA** banner appears in the top-right corner of every page as a reminder.
 
+## Version History
+
+Every time the vault is saved a snapshot is appended to a local history stored in your browser. Click **Version History** next to the export button to restore earlier snapshots.
+

--- a/app-main/components/DeleteZone.tsx
+++ b/app-main/components/DeleteZone.tsx
@@ -9,6 +9,7 @@ export default function DeleteZone(){
   const onDelete = () => {
     if(confirm('Delete uploaded vault data?')){
       storage.clearVault()
+      storage.clearHistory()
       setVault(null)
       setGraph({ nodes: [], edges: [] })
     }

--- a/app-main/components/EditItemModal.tsx
+++ b/app-main/components/EditItemModal.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { useVault } from '@/contexts/VaultStore'
 import { useGraph } from '@/contexts/GraphStore'
 import { parseVault } from '@/lib/parseVault'
+import * as storage from '@/lib/storage'
 import { EyeIcon, EyeSlashIcon, PlusIcon, TrashIcon, StarIcon } from '@heroicons/react/24/outline'
 import { StarIcon as StarSolid } from '@heroicons/react/24/solid'
 
@@ -91,6 +92,7 @@ export default function EditItemModal({ index, onClose }: Props) {
     const updatedVault = { ...vault, items }
     setVault(updatedVault)
     setGraph(parseVault(updatedVault))
+    storage.saveVault(JSON.stringify(updatedVault))
     onClose()
   }
 

--- a/app-main/components/VersionHistoryModal.tsx
+++ b/app-main/components/VersionHistoryModal.tsx
@@ -1,0 +1,50 @@
+'use client'
+import { useEffect, useState } from 'react'
+import { useVault } from '@/contexts/VaultStore'
+import { useGraph } from '@/contexts/GraphStore'
+import { parseVault } from '@/lib/parseVault'
+import * as storage from '@/lib/storage'
+
+interface Entry { timestamp: number; data: string }
+
+export default function VersionHistoryModal({ onClose }: { onClose: () => void }) {
+  const [history, setHistory] = useState<Entry[]>([])
+  const { setVault } = useVault()
+  const { setGraph } = useGraph()
+
+  useEffect(() => {
+    setHistory(storage.loadHistory().slice().reverse())
+  }, [])
+
+  const loadVersion = (entry: Entry) => {
+    try {
+      const data = JSON.parse(entry.data)
+      setVault(data)
+      setGraph(parseVault(data))
+      storage.saveVault(entry.data)
+      onClose()
+    } catch {
+      alert('Failed to load version')
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50" onClick={onClose}>
+      <div className="bg-white rounded-md shadow-md w-full max-w-md p-6" onClick={e => e.stopPropagation()}>
+        <h2 className="text-xl font-semibold mb-4">Version History</h2>
+        <ul className="space-y-2 max-h-80 overflow-y-auto">
+          {history.map((h, idx) => (
+            <li key={idx} className="flex justify-between items-center border-b pb-1">
+              <span>{new Date(h.timestamp).toLocaleString()}</span>
+              <button className="text-indigo-600 underline" onClick={() => loadVersion(h)}>Load</button>
+            </li>
+          ))}
+          {history.length === 0 && <li>No versions stored.</li>}
+        </ul>
+        <div className="text-right mt-4">
+          <button onClick={onClose} className="px-3 py-2 bg-gray-200 rounded">Close</button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app-main/lib/storage.ts
+++ b/app-main/lib/storage.ts
@@ -1,14 +1,34 @@
 const KEY = 'vault-data'
 const POS_KEY = 'vault-positions'
+const HISTORY_KEY = 'vault-history'
 
-export const saveVault = (raw:string)=>{
-  try{ localStorage.setItem(KEY, raw) }catch{}
+export const saveVault = (raw: string) => {
+  try {
+    localStorage.setItem(KEY, raw)
+    const histRaw = localStorage.getItem(HISTORY_KEY)
+    const hist = histRaw ? JSON.parse(histRaw) : []
+    hist.push({ timestamp: Date.now(), data: raw })
+    localStorage.setItem(HISTORY_KEY, JSON.stringify(hist))
+  } catch {}
 }
 export const loadVault = ()=>{
   try{ const raw = localStorage.getItem(KEY); return raw? JSON.parse(raw):null }catch{ return null }
 }
 export const clearVault = ()=>{
   try{ localStorage.removeItem(KEY) }catch{}
+}
+
+export const loadHistory = (): { timestamp: number; data: string }[] => {
+  try {
+    const raw = localStorage.getItem(HISTORY_KEY)
+    return raw ? JSON.parse(raw) : []
+  } catch {
+    return []
+  }
+}
+
+export const clearHistory = () => {
+  try { localStorage.removeItem(HISTORY_KEY) } catch {}
 }
 
 export const savePositions = (map:Record<string,{x:number,y:number}>)=>{

--- a/app-main/pages/vault.tsx
+++ b/app-main/pages/vault.tsx
@@ -3,6 +3,7 @@ import DeleteZone from '@/components/DeleteZone'
 import VaultDiagram from '@/components/VaultDiagram'
 import ChatInterface from '@/components/ChatInterface'
 import ExportButton from '@/components/ExportButton'
+import VersionHistoryModal from '@/components/VersionHistoryModal'
 import TemplateZone from '@/components/TemplateZone'
 import VaultItemList from '@/components/VaultItemList'
 import EditItemModal from '@/components/EditItemModal'
@@ -19,6 +20,7 @@ export default function Vault() {
 
   const [showList, setShowList] = useState(true)
   const [showChat, setShowChat] = useState(true)
+  const [showHistory, setShowHistory] = useState(false)
 
 
   const handleLoad = (data: any) => {
@@ -37,7 +39,17 @@ export default function Vault() {
           <TemplateZone onGenerate={handleLoad} />
         </>
       )}
-      {vault && <ExportButton />}
+      {vault && (
+        <div className="flex gap-2">
+          <ExportButton />
+          <button
+            onClick={() => setShowHistory(true)}
+            className="px-4 py-2 bg-indigo-600 text-white rounded self-start"
+          >
+            Version History
+          </button>
+        </div>
+      )}
       <div className="flex flex-col md:flex-row gap-4">
 
         {vault && showList && (
@@ -51,6 +63,9 @@ export default function Vault() {
       </div>
       {editIndex !== null && (
         <EditItemModal index={editIndex} onClose={() => setEditIndex(null)} />
+      )}
+      {showHistory && (
+        <VersionHistoryModal onClose={() => setShowHistory(false)} />
       )}
     </div>
   )


### PR DESCRIPTION
## Summary
- track historical vault snapshots in `localStorage`
- provide modal to view and load versions
- allow clearing history when deleting data
- persist edits back to localStorage
- expose `Version History` button next to `Export Vault`
- document the new feature in README

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6841a132a554832c824706826c276e64