### PR TITLE
Filter already-selected 2FA providers

### DIFF
--- a/app-main/components/EditItemModal.tsx
+++ b/app-main/components/EditItemModal.tsx
@@ -333,11 +333,16 @@ export default function EditItemModal({ index, onClose }: Props) {
                   className="border border-gray-300 rounded-md px-2 py-1 flex-1"
                 >
                   <option value="">Select item…</option>
-                  {recoveryItems.map((ri: any) => (
-                    <option key={ri.id} value={ri.id}>
-                      {ri.name}
-                    </option>
-                  ))}
+                  {recoveryItems
+                    .filter((ri: any) => {
+                      const slug = slugFor(String(ri.id))
+                      return slug && !providers.includes(slug)
+                    })
+                    .map((ri: any) => (
+                      <option key={ri.id} value={ri.id}>
+                        {ri.name}
+                      </option>
+                    ))}
                 </select>
                 <button type="button" onClick={addTwofaMap} className="p-1 bg-gray-100 rounded hover:bg-gray-200">
                   Add


### PR DESCRIPTION
## Summary
- update EditItemModal to hide providers that are already selected

## Testing
- `npm run build` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6841a1dd7734832c933118735d1b28e0