### PR TITLE
Enable dependencies for recovery methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ The recovered items would reference the recovering identifier:
 {"recovered_by": ["gmail-1863"]}
 ```
 
+Items flagged as recovery methods can also use these mappings. This allows a recovery
+method to depend on another recovery method or require additional two-factor
+providers.
+
 Keeping the value structured allows the application to automatically create edges between items when parsing the vault.
 
 ## Setup

--- a/app-main/components/EditItemModal.tsx
+++ b/app-main/components/EditItemModal.tsx
@@ -286,10 +286,9 @@ export default function EditItemModal({ index, onClose }: Props) {
             Recovery Method
           </label>
         </div>
-        {!isRecovery && (
-          <div className="space-y-2">
-            <div>
-              <label className="block text-sm font-medium mb-1">Recovery Items</label>
+        <div className="space-y-2">
+          <div>
+            <label className="block text-sm font-medium mb-1">Recovery Items</label>
               {recoveredBy.map((slug) => (
                 <div key={slug} className="flex items-center gap-2 mb-1">
                   <span className="flex-1 text-sm">{nameForSlug(slug)}</span>
@@ -345,7 +344,6 @@ export default function EditItemModal({ index, onClose }: Props) {
               </div>
             </div>
           </div>
-        )}
         <div>
           <label className="block text-sm font-medium mb-2">Custom Fields</label>
             <div className="flex items-center space-x-2 mb-2">

--- a/app-main/components/VaultNode.tsx
+++ b/app-main/components/VaultNode.tsx
@@ -41,7 +41,7 @@ export default function VaultNode({ id, data }: NodeProps) {
       {data.isRecovery && (
         <span className="text-xs font-semibold text-purple-600">Recovery Node</span>
       )}
-      {!data.isRecovery && data.has2fa && (
+      {data.has2fa && (
         <span className="text-xs font-semibold text-sky-600">2FA Enabled</span>
       )}
 


### PR DESCRIPTION
## Summary
- allow editing recovery and 2FA relationships for recovery methods
- show 2FA indicator on all nodes
- document recovery methods referencing their own dependencies

## Testing
- `npm run -s build`

------
https://chatgpt.com/codex/tasks/task_e_6841a2161acc832c9fcb57fcc70d4cc5