### PR TITLE
Add item creation modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Keeping the value structured allows the application to automatically create edge
 After installing dependencies with `npm install`, start the development server with `npm run dev`.
 Open the vault page and you will see a chat panel next to the diagram. Enter your OpenAI API key and select a model from the drop-down to enable chatting with ChatGPT. The key and model are saved in your browser's local storage.
 
+Use the list panel's **New** button to create additional items with the same UI used for editing.
+
 
 To enable Google Analytics, copy `app-main/.env.local.example` to `app-main/.env.local` and set `NEXT_PUBLIC_GA_ID` to your measurement ID.
 

--- a/app-main/components/EditItemModal.tsx
+++ b/app-main/components/EditItemModal.tsx
@@ -2,18 +2,35 @@ import { useState } from 'react'
 import { useVault } from '@/contexts/VaultStore'
 import { useGraph } from '@/contexts/GraphStore'
 import { parseVault } from '@/lib/parseVault'
-import { EyeIcon, EyeSlashIcon, PlusIcon, TrashIcon, StarIcon } from '@heroicons/react/24/outline'
+import {
+  EyeIcon,
+  EyeSlashIcon,
+  PlusIcon,
+  TrashIcon,
+  StarIcon,
+} from '@heroicons/react/24/outline'
 import { StarIcon as StarSolid } from '@heroicons/react/24/solid'
 
-type Props = { index: number; onClose: () => void }
+type Props = { index?: number; onClose: () => void }
 
 export default function EditItemModal({ index, onClose }: Props) {
   const { vault, setVault } = useVault()
   if (!vault) return null
-  const original = vault.items?.[index]
-  if (!original) return null
 
-  const [item, setItem] = useState<any>(() => JSON.parse(JSON.stringify(original)))
+  const original =
+    index !== undefined && index > -1 ? vault.items?.[index] : null
+
+  const [item, setItem] = useState<any>(() =>
+    original
+      ? JSON.parse(JSON.stringify(original))
+      : {
+          id: (crypto as any).randomUUID(),
+          type: 1,
+          name: '',
+          login: {},
+          fields: [],
+        }
+  )
   const [showPassword, setShowPassword] = useState(false)
   const [showTotp, setShowTotp] = useState(false)
   const [newFieldType, setNewFieldType] = useState('0')
@@ -87,7 +104,11 @@ export default function EditItemModal({ index, onClose }: Props) {
 
   const handleSave = () => {
     const items = [...vault.items]
-    items[index] = item
+    if (index !== undefined && index > -1) {
+      items[index] = item
+    } else {
+      items.push(item)
+    }
     const updatedVault = { ...vault, items }
     setVault(updatedVault)
     setGraph(parseVault(updatedVault))
@@ -148,7 +169,9 @@ export default function EditItemModal({ index, onClose }: Props) {
   return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50" onClick={onClose}>
       <div className="bg-white rounded-md shadow-md w-full max-w-xl p-6" onClick={e => e.stopPropagation()}>
-        <h2 className="text-xl font-semibold mb-4">Edit Item</h2>
+        <h2 className="text-xl font-semibold mb-4">
+          {index !== undefined && index > -1 ? 'Edit Item' : 'New Item'}
+        </h2>
         <div className="space-y-4 max-h-[70vh] overflow-y-auto">
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div>
@@ -462,16 +485,18 @@ export default function EditItemModal({ index, onClose }: Props) {
                 <StarIcon className="h-6 w-6 text-gray-400" />
               )}
             </button>
-            <button
-              type="button"
-              onClick={() => {
-                const items = vault.items.filter((_: any, i: number) => i !== index)
-                setVault({ ...vault, items })
-                onClose()
-              }}
-            >
-              <TrashIcon className="h-6 w-6 text-red-600 hover:text-red-800" />
-            </button>
+            {index !== undefined && index > -1 && (
+              <button
+                type="button"
+                onClick={() => {
+                  const items = vault.items.filter((_: any, i: number) => i !== index)
+                  setVault({ ...vault, items })
+                  onClose()
+                }}
+              >
+                <TrashIcon className="h-6 w-6 text-red-600 hover:text-red-800" />
+              </button>
+            )}
           </div>
         </div>
       </div>

--- a/app-main/components/VaultItemList.tsx
+++ b/app-main/components/VaultItemList.tsx
@@ -3,9 +3,13 @@ import { useState } from 'react'
 import { useVault } from '@/contexts/VaultStore'
 
 import { useHoverStore } from '@/contexts/HoverStore'
-import { EllipsisVerticalIcon, XMarkIcon } from '@heroicons/react/24/solid'
+import {
+  EllipsisVerticalIcon,
+  PlusIcon,
+  XMarkIcon,
+} from '@heroicons/react/24/solid'
 
-type Props = { onEdit: (index: number) => void; onClose?: () => void }
+type Props = { onEdit: (index: number) => void; onClose?: () => void; onCreate?: () => void }
 
 
 const domainFrom = (raw?: string) => {
@@ -22,7 +26,7 @@ const domainFrom = (raw?: string) => {
 }
 
 
-export default function VaultItemList({ onEdit, onClose }: Props) {
+export default function VaultItemList({ onEdit, onClose, onCreate }: Props) {
   const { vault } = useVault()
   const [selected, setSelected] = useState<number[]>([])
   const { hoveredId, setHoveredId } = useHoverStore()
@@ -47,14 +51,25 @@ export default function VaultItemList({ onEdit, onClose }: Props) {
   return (
     <div className="border rounded w-full md:w-80 overflow-auto max-h-[80vh]">
 
-      {onClose && (
-        <div className="flex justify-end p-1">
-          <button
-            onClick={onClose}
-            className="text-xs text-gray-500 hover:text-gray-700"
-          >
-            Close
-          </button>
+      {(onClose || onCreate) && (
+        <div className="flex justify-between items-center p-1">
+          {onClose && (
+            <button
+              onClick={onClose}
+              className="text-xs text-gray-500 hover:text-gray-700"
+            >
+              Close
+            </button>
+          )}
+          {onCreate && (
+            <button
+              onClick={onCreate}
+              className="text-xs text-blue-600 hover:text-blue-800 flex items-center gap-1"
+            >
+              <PlusIcon className="h-4 w-4" />
+              New
+            </button>
+          )}
         </div>
       )}
 

--- a/app-main/pages/vault.tsx
+++ b/app-main/pages/vault.tsx
@@ -16,6 +16,7 @@ export default function Vault() {
   const { setGraph } = useGraph()
   const { vault, setVault } = useVault()
   const [editIndex, setEditIndex] = useState<number | null>(null)
+  const [creating, setCreating] = useState(false)
 
   const [showList, setShowList] = useState(true)
   const [showChat, setShowChat] = useState(true)
@@ -44,6 +45,7 @@ export default function Vault() {
           <VaultItemList
             onEdit={(i) => setEditIndex(i)}
             onClose={() => setShowList(false)}
+            onCreate={() => setCreating(true)}
           />
         )}
         <VaultDiagram />
@@ -52,6 +54,7 @@ export default function Vault() {
       {editIndex !== null && (
         <EditItemModal index={editIndex} onClose={() => setEditIndex(null)} />
       )}
+      {creating && <EditItemModal onClose={() => setCreating(false)} />}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- enable `EditItemModal` to also create new items
- show a "New" button in the list panel
- wire up creation flow on the vault page
- document how to create items

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841a28bea14832cbc460119b3a1be21