### PR TITLE
Add function-calling API and GPT‑4o default

### DIFF
--- a/app-main/components/ChatInterface.tsx
+++ b/app-main/components/ChatInterface.tsx
@@ -1,6 +1,10 @@
 'use client'
 import { useEffect, useState } from 'react'
 import { XMarkIcon } from '@heroicons/react/24/solid'
+import { useVault } from '@/contexts/VaultStore'
+import { useGraph } from '@/contexts/GraphStore'
+import { parseVault } from '@/lib/parseVault'
+import * as storage from '@/lib/storage'
 
 interface Message {
   role: 'user' | 'assistant' | 'system'
@@ -35,7 +39,7 @@ type Props = { onClose?: () => void }
 
 export default function ChatInterface({ onClose }: Props) {
   const [apiKey, setApiKey]   = useState('')
-  const [model, setModel]     = useState<(typeof MODELS)[number]>('gpt-3.5-turbo')
+  const [model, setModel]     = useState<(typeof MODELS)[number]>('gpt-4o')
   const [input, setInput]     = useState('')
   const [messages, setMessages] = useState<Message[]>([
     { role: 'system', content: SYSTEM_PROMPT },
@@ -76,8 +80,125 @@ export default function ChatInterface({ onClose }: Props) {
       localStorage.removeItem(MODEL_KEY)
     }
     setApiKey('')
-    setModel('gpt-3.5-turbo')
+    setModel('gpt-4o')
     setMessages([{ role: 'system', content: SYSTEM_PROMPT }])
+  }
+
+  const { vault, setVault, addRecoverySlug, addTwofa, createItem, updateItemBySlug } = useVault()
+  const { setGraph } = useGraph()
+
+  const updateGraph = (v: any) => {
+    setGraph(parseVault(v))
+    storage.saveVault(JSON.stringify(v))
+  }
+
+  const FUNCTIONS = [
+    {
+      type: 'function',
+      function: {
+        name: 'create_item',
+        description: 'Create a new item in the vault',
+        parameters: {
+          type: 'object',
+          properties: {
+            name: { type: 'string' },
+            slug: { type: 'string' },
+            username: { type: 'string' },
+            password: { type: 'string' },
+            uri: { type: 'string' },
+            isRecovery: { type: 'boolean' }
+          },
+          required: ['name', 'slug']
+        }
+      }
+    },
+    {
+      type: 'function',
+      function: {
+        name: 'edit_item',
+        description: 'Edit a field on an existing item identified by its slug',
+        parameters: {
+          type: 'object',
+          properties: {
+            slug: { type: 'string' },
+            field: { type: 'string', enum: ['name', 'username', 'password', 'uri'] },
+            value: { type: 'string' }
+          },
+          required: ['slug', 'field', 'value']
+        }
+      }
+    },
+    {
+      type: 'function',
+      function: {
+        name: 'map_recovery',
+        description: 'Map a recovery item to recover another item',
+        parameters: {
+          type: 'object',
+          properties: {
+            source_slug: { type: 'string' },
+            target_slug: { type: 'string' }
+          },
+          required: ['source_slug', 'target_slug']
+        }
+      }
+    },
+    {
+      type: 'function',
+      function: {
+        name: 'map_2fa',
+        description: 'Map a 2FA provider to an item',
+        parameters: {
+          type: 'object',
+          properties: {
+            service_slug: { type: 'string' },
+            provider_slug: { type: 'string' }
+          },
+          required: ['service_slug', 'provider_slug']
+        }
+      }
+    }
+  ] as const
+
+  const handleToolCalls = (calls: any[]) => {
+    if (!vault) return
+    calls.forEach((c) => {
+      try {
+        const { name, arguments: args } = c.function
+        const data = JSON.parse(args || '{}')
+        if (name === 'create_item') {
+          createItem(data)
+          const updated = { ...useVault.getState().vault }
+          if (updated) {
+            setVault(updated)
+            updateGraph(updated)
+          }
+        } else if (name === 'edit_item') {
+          updateItemBySlug(data.slug, data.field, data.value)
+          const updated = { ...useVault.getState().vault }
+          if (updated) {
+            setVault(updated)
+            updateGraph(updated)
+          }
+        } else if (name === 'map_recovery') {
+          addRecoverySlug(data.source_slug, data.target_slug)
+          const updated = { ...useVault.getState().vault }
+          if (updated) {
+            setVault(updated)
+            updateGraph(updated)
+          }
+        } else if (name === 'map_2fa') {
+          addTwofa(data.service_slug, data.provider_slug)
+          const updated = { ...useVault.getState().vault }
+          if (updated) {
+            setVault(updated)
+            updateGraph(updated)
+          }
+        }
+      } catch (err) {
+        console.error('tool call error', err)
+      }
+    })
   }
 
   const send = async () => {
@@ -96,10 +217,12 @@ export default function ChatInterface({ onClose }: Props) {
           'Content-Type': 'application/json',
           Authorization: `Bearer ${apiKey}`,
         },
-        body: JSON.stringify({ model, messages: history }),
+        body: JSON.stringify({ model, messages: history, tools: FUNCTIONS, tool_choice: 'auto' }),
       })
-      const data  = await res.json()
-      const reply = data.choices?.[0]?.message?.content
+      const data = await res.json()
+      const msg = data.choices?.[0]?.message
+      if (msg?.tool_calls) handleToolCalls(msg.tool_calls)
+      const reply = msg?.content
       if (reply) setMessages((m) => [...m, { role: 'assistant', content: reply }])
     } catch (err) {
       console.error(err)

--- a/app-main/contexts/VaultStore.ts
+++ b/app-main/contexts/VaultStore.ts
@@ -6,6 +6,21 @@ interface VaultState {
   setVault: (v: any) => void
   updateItem: (index: number, field: string, value: string) => void
   addRecovery: (sourceId: string, targetId: string) => void
+  addRecoverySlug: (srcSlug: string, tgtSlug: string) => void
+  addTwofa: (serviceSlug: string, providerSlug: string) => void
+  createItem: (item: {
+    name: string
+    slug: string
+    username?: string
+    password?: string
+    uri?: string
+    isRecovery?: boolean
+  }) => void
+  updateItemBySlug: (
+    slug: string,
+    field: 'name' | 'username' | 'password' | 'uri',
+    value: string
+  ) => void
 }
 
 export const useVault = create<VaultState>((set, get) => ({
@@ -74,6 +89,122 @@ export const useVault = create<VaultState>((set, get) => ({
     items[srcIdx] = src
     items[tgtIdx] = tgt
 
+    set({ vault: { ...v, items } })
+  },
+  addRecoverySlug: (srcSlug, tgtSlug) => {
+    const v = get().vault
+    if (!v || !v.items) return
+    const items = [...v.items]
+
+    const srcIdx = items.findIndex((i: any) =>
+      i.fields?.some((f: any) => f.name === 'vaultdiagram-id' && f.value === srcSlug)
+    )
+    const tgtIdx = items.findIndex((i: any) =>
+      i.fields?.some((f: any) => f.name === 'vaultdiagram-id' && f.value === tgtSlug)
+    )
+    if (srcIdx === -1 || tgtIdx === -1) return
+
+    const src = { ...items[srcIdx] }
+    const tgt = { ...items[tgtIdx] }
+
+    const updateMap = (item: any, key: 'recovers' | 'recovered_by', slug: string) => {
+      let field = item.fields?.find((f: any) => f.name === 'vaultdiagram-recovery-map')
+      if (!field) {
+        field = { name: 'vaultdiagram-recovery-map', value: '{}', type: 0 }
+        item.fields = item.fields ? [...item.fields, field] : [field]
+      }
+      let map: any
+      try {
+        map = JSON.parse(field.value || '{}')
+      } catch {
+        map = {}
+      }
+      const arr = Array.isArray(map[key]) ? map[key] : []
+      if (!arr.includes(slug)) arr.push(slug)
+      map[key] = arr
+      field.value = JSON.stringify(map)
+    }
+
+    updateMap(tgt, 'recovers', srcSlug)
+    updateMap(src, 'recovered_by', tgtSlug)
+
+    items[srcIdx] = src
+    items[tgtIdx] = tgt
+
+    set({ vault: { ...v, items } })
+  },
+  addTwofa: (serviceSlug, providerSlug) => {
+    const v = get().vault
+    if (!v || !v.items) return
+    const items = [...v.items]
+
+    const idx = items.findIndex((i: any) =>
+      i.fields?.some((f: any) => f.name === 'vaultdiagram-id' && f.value === serviceSlug)
+    )
+    if (idx === -1) return
+
+    const item = { ...items[idx] }
+    let field = item.fields?.find((f: any) => f.name === 'vaultdiagram-2fa-map')
+    if (!field) {
+      field = { name: 'vaultdiagram-2fa-map', value: '{}', type: 0 }
+      item.fields = item.fields ? [...item.fields, field] : [field]
+    }
+    let map: any
+    try {
+      map = JSON.parse(field.value || '{}')
+    } catch {
+      map = {}
+    }
+    const arr = Array.isArray(map.providers) ? map.providers : []
+    if (!arr.includes(providerSlug)) arr.push(providerSlug)
+    map.providers = arr
+    field.value = JSON.stringify(map)
+
+    items[idx] = item
+    set({ vault: { ...v, items } })
+  },
+  createItem: (itemData) => {
+    const v = get().vault
+    if (!v || !v.items) return
+    const items = [...v.items]
+    const item: any = {
+      id: (crypto as any).randomUUID(),
+      type: 1,
+      name: itemData.name,
+      login: {},
+      fields: [{ name: 'vaultdiagram-id', value: itemData.slug, type: 0 }],
+    }
+    if (itemData.username) item.login.username = itemData.username
+    if (itemData.password) item.login.password = itemData.password
+    if (itemData.uri) item.login.uris = [{ uri: itemData.uri, match: null }]
+    if (itemData.isRecovery)
+      item.fields.push({ name: 'recovery_node', value: 'true', type: 0 })
+
+    items.push(item)
+    set({ vault: { ...v, items } })
+  },
+  updateItemBySlug: (slug, field, value) => {
+    const v = get().vault
+    if (!v || !v.items) return
+    const items = [...v.items]
+    const idx = items.findIndex((i: any) =>
+      i.fields?.some((f: any) => f.name === 'vaultdiagram-id' && f.value === slug)
+    )
+    if (idx === -1) return
+
+    const item = { ...items[idx] }
+    if (field === 'name') item.name = value
+    else if (field === 'username')
+      item.login = { ...item.login, username: value }
+    else if (field === 'password')
+      item.login = { ...item.login, password: value }
+    else if (field === 'uri') {
+      const uris = item.login?.uris?.length ? [...item.login.uris] : [{ match: null, uri: '' }]
+      uris[0] = { ...uris[0], uri: value }
+      item.login = { ...item.login, uris }
+    }
+
+    items[idx] = item
     set({ vault: { ...v, items } })
   },
 }))


### PR DESCRIPTION
## Summary
- integrate OpenAI function calling in `ChatInterface`
- update default ChatGPT model to **gpt‑4o**
- extend `VaultStore` with helper actions for item creation, editing, recovery and 2FA mapping

## Testing
- `npm run build`
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6841a88352b4832c9f4a08edfe92074b