### PR TITLE
Ensure recovery items appear first

### DIFF
--- a/app-main/components/VaultItemList.tsx
+++ b/app-main/components/VaultItemList.tsx
@@ -54,6 +54,21 @@ export default function VaultItemList({ onEdit, onClose, onCreate }: Props) {
     setSelected([])
   }
 
+  // sort indexes so recovery methods appear first in the list
+  const orderedIndexes = vault.items
+    .map((item: any, idx: number) => ({ item, idx }))
+    .sort((a, b) => {
+      const aRec = a.item.fields?.some(
+        (f: any) => f.name === 'recovery_node' && String(f.value).toLowerCase() === 'true',
+      )
+      const bRec = b.item.fields?.some(
+        (f: any) => f.name === 'recovery_node' && String(f.value).toLowerCase() === 'true',
+      )
+      if (aRec === bRec) return 0
+      return aRec ? -1 : 1
+    })
+    .map((o) => o.idx)
+
   return (
     <div className="border rounded w-full md:w-80 overflow-auto max-h-[80vh]">
 
@@ -91,9 +106,10 @@ export default function VaultItemList({ onEdit, onClose, onCreate }: Props) {
           </tr>
         </thead>
         <tbody>
-          {vault.items
-            .filter((_: any, index: number) => !hidden.includes(index))
-            .map((item: any, index: number) => {
+          {orderedIndexes
+            .filter((index: number) => !hidden.includes(index))
+            .map((index: number) => {
+            const item = vault.items[index]
             const uri = item.login?.uris?.[0]?.uri
             const domain = domainFrom(uri)
             const logo = `https://www.google.com/s2/favicons?domain=${domain || 'example.com'}`

--- a/app-main/lib/parseVault.ts
+++ b/app-main/lib/parseVault.ts
@@ -49,8 +49,20 @@ export const parseVault = (vault: any) => {
 
   // -------------------------------------------------------------------------
   // Pass 1: create all nodes and collect slugs
+  // Recovery methods appear first so they get placed in the top rows
   // -------------------------------------------------------------------------
-  vault.items.forEach((item: any) => {
+  const itemsSorted = [...vault.items].sort((a: any, b: any) => {
+    const aRec = a.fields?.some(
+      (f: any) => f.name === 'recovery_node' && String(f.value).toLowerCase() === 'true',
+    )
+    const bRec = b.fields?.some(
+      (f: any) => f.name === 'recovery_node' && String(f.value).toLowerCase() === 'true',
+    )
+    if (aRec === bRec) return 0
+    return aRec ? -1 : 1
+  })
+
+  itemsSorted.forEach((item: any) => {
     const itemId = `item-${item.id}`
     const firstUri = item.login?.uris?.[0]?.uri
     const dom = domainFrom(firstUri)


### PR DESCRIPTION
## Summary
- sort recovery nodes first when building the diagram
- list recovery nodes before other items in the item list

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841a91dd65c832ca716ecefba5f240c