### PR TITLE
Add search field for vault items

### DIFF
--- a/app-main/components/VaultItemList.tsx
+++ b/app-main/components/VaultItemList.tsx
@@ -30,6 +30,7 @@ export default function VaultItemList({ onEdit, onClose, onCreate }: Props) {
   const { vault } = useVault()
   const [selected, setSelected] = useState<number[]>([])
   const [hidden, setHidden] = useState<number[]>([])
+  const [query, setQuery] = useState('')
   const { hoveredId, setHoveredId } = useHoverStore()
 
 
@@ -79,6 +80,16 @@ export default function VaultItemList({ onEdit, onClose, onCreate }: Props) {
         </div>
       )}
 
+      <div className="p-1 sticky top-0 bg-white z-10">
+        <input
+          type="text"
+          placeholder="Search"
+          value={query}
+          onChange={e => setQuery(e.target.value)}
+          className="w-full border px-2 py-1 rounded text-sm"
+        />
+      </div>
+
 
       <table className="w-full table-auto border-separate border-spacing-y-1">
         <thead className="text-sm text-gray-500 sticky top-0 bg-white">
@@ -93,6 +104,19 @@ export default function VaultItemList({ onEdit, onClose, onCreate }: Props) {
         <tbody>
           {vault.items
             .filter((_: any, index: number) => !hidden.includes(index))
+            .filter((item: any) => {
+              const q = query.toLowerCase()
+              if (!q) return true
+              if (item.name?.toLowerCase().includes(q)) return true
+              if (item.login?.username?.toLowerCase().includes(q)) return true
+              if (
+                item.login?.uris?.some((u: any) =>
+                  String(u.uri).toLowerCase().includes(q)
+                )
+              )
+                return true
+              return false
+            })
             .map((item: any, index: number) => {
             const uri = item.login?.uris?.[0]?.uri
             const domain = domainFrom(uri)


### PR DESCRIPTION
## Summary
- add search query state and input box
- filter item list by search query

## Testing
- `npm install`
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6841a95a8438832c842af98c78385691