### PR TITLE
Add header with language switcher and link

### DIFF
--- a/app-main/components/Header.tsx
+++ b/app-main/components/Header.tsx
@@ -1,0 +1,39 @@
+'use client'
+import Link from 'next/link'
+import { useLanguage } from '@/contexts/LanguageStore'
+import { useEffect } from 'react'
+
+const labels = {
+  en: { home: 'Home', diagram: 'Diagram', about: 'About', en: 'English', da: 'Dansk' },
+  da: { home: 'Hjem', diagram: 'Diagram', about: 'Om', en: 'Engelsk', da: 'Dansk' }
+}
+
+export default function Header() {
+  const { lang, setLang } = useLanguage()
+
+  useEffect(() => {
+    const saved = localStorage.getItem('lang') as 'en' | 'da' | null
+    if (saved) setLang(saved)
+  }, [setLang])
+
+  useEffect(() => {
+    localStorage.setItem('lang', lang)
+  }, [lang])
+
+  const t = labels[lang]
+
+  return (
+    <header className="bg-gray-800 text-white p-4 flex justify-between">
+      <nav className="flex gap-4">
+        <Link href="/">{t.home}</Link>
+        <Link href="/vault">{t.diagram}</Link>
+        <Link href="/about">{t.about}</Link>
+      </nav>
+      <div className="flex gap-2">
+        <button onClick={() => setLang('en')} className={lang==='en' ? 'underline' : ''}>{t.en}</button>
+        <span>|</span>
+        <button onClick={() => setLang('da')} className={lang==='da' ? 'underline' : ''}>{t.da}</button>
+      </div>
+    </header>
+  )
+}

--- a/app-main/components/VaultItemList.tsx
+++ b/app-main/components/VaultItemList.tsx
@@ -77,7 +77,7 @@ export default function VaultItemList({ onEdit, onClose, onCreate }: Props) {
   // sort indexes so recovery methods appear first in the list
   const orderedIndexes = vault.items
     .map((item: any, idx: number) => ({ item, idx }))
-    .sort((a, b) => {
+    .sort((a: { item: any; idx: number }, b: { item: any; idx: number }) => {
       const aRec = a.item.fields?.some(
         (f: any) => f.name === 'recovery_node' && String(f.value).toLowerCase() === 'true',
       )
@@ -87,7 +87,7 @@ export default function VaultItemList({ onEdit, onClose, onCreate }: Props) {
       if (aRec === bRec) return 0
       return aRec ? -1 : 1
     })
-    .map((o) => o.idx)
+    .map((o: { item: any; idx: number }) => o.idx)
 
   const startResize = (e: React.MouseEvent<HTMLDivElement>) => {
     e.preventDefault()

--- a/app-main/contexts/LanguageStore.ts
+++ b/app-main/contexts/LanguageStore.ts
@@ -1,0 +1,14 @@
+'use client'
+import { create } from 'zustand'
+
+export type Lang = 'en' | 'da'
+
+interface LanguageState {
+  lang: Lang
+  setLang: (l: Lang) => void
+}
+
+export const useLanguage = create<LanguageState>(set => ({
+  lang: 'en',
+  setLang: (l) => set({ lang: l })
+}))

--- a/app-main/pages/_app.tsx
+++ b/app-main/pages/_app.tsx
@@ -9,6 +9,7 @@ import { useVault } from '@/contexts/VaultStore'
 import { loadVault } from '@/lib/storage'
 import { parseVault } from '@/lib/parseVault'
 import AlphaBanner from '@/components/AlphaBanner'
+import Header from '@/components/Header'
 
 export default function App({ Component, pageProps }: AppProps) {
   const { setGraph } = useGraph()
@@ -29,6 +30,12 @@ export default function App({ Component, pageProps }: AppProps) {
       router.events.off('routeChangeComplete', handleRouteChange)
     }
   }, [router])
-  return <Component {...pageProps} />
+  return (
+    <>
+      <AlphaBanner />
+      <Header />
+      <Component {...pageProps} />
+    </>
+  )
 
 }

--- a/app-main/pages/index.tsx
+++ b/app-main/pages/index.tsx
@@ -1,19 +1,31 @@
-import React from 'react';
+import Link from 'next/link'
+import { useLanguage } from '@/contexts/LanguageStore'
 
 export default function Home() {
+  const { lang } = useLanguage()
+
+  const t = {
+    en: {
+      title: 'Welcome to Vaultdiagram',
+      intro: 'This application visualizes your Bitwarden vault and helps you understand recovery relationships.',
+      open: 'Open Diagram'
+    },
+    da: {
+      title: 'Velkommen til Vaultdiagram',
+      intro: 'Dette program viser dit Bitwarden-hvelv som et diagram og forklarer gendannelsesforhold.',
+      open: 'Åbn diagram'
+    }
+  }
+
+  const l = t[lang]
+
   return (
-    <main
-      style={{
-        minHeight: '100vh',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        background: '#18181b',
-        color: '#fff',
-        fontFamily: 'sans-serif',
-      }}
-    >
-      <h1>Hello, World!</h1>
+    <main className="flex flex-col items-center justify-center gap-6 min-h-screen bg-gray-900 text-white">
+      <h1 className="text-3xl font-semibold">{l.title}</h1>
+      <p className="max-w-xl text-center text-lg px-4">{l.intro}</p>
+      <Link href="/vault" className="px-4 py-2 bg-blue-600 rounded">
+        {l.open}
+      </Link>
     </main>
-  );
+  )
 }


### PR DESCRIPTION
## Summary
- create `LanguageStore` state for language selection
- add `Header` with nav links and language switcher
- insert the header on every page via `_app.tsx`
- rewrite index page with an intro and link to the diagram
- fix TypeScript implicit `any` issues in `VaultItemList`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6841af644fcc832cb0505861ad55690f