### PR TITLE
Enable chat to store TOTP and notes

### DIFF
--- a/app-main/contexts/VaultStore.ts
+++ b/app-main/contexts/VaultStore.ts
@@ -13,12 +13,14 @@ interface VaultState {
     slug: string
     username?: string
     password?: string
+    totp?: string
     uri?: string
+    notes?: string
     isRecovery?: boolean
   }) => void
   updateItemBySlug: (
     slug: string,
-    field: 'name' | 'username' | 'password' | 'uri',
+    field: 'name' | 'username' | 'password' | 'totp' | 'uri' | 'notes',
     value: string
   ) => void
 }
@@ -176,7 +178,9 @@ export const useVault = create<VaultState>((set, get) => ({
     }
     if (itemData.username) item.login.username = itemData.username
     if (itemData.password) item.login.password = itemData.password
+    if (itemData.totp) item.login.totp = itemData.totp
     if (itemData.uri) item.login.uris = [{ uri: itemData.uri, match: null }]
+    if (itemData.notes) item.notes = itemData.notes
     if (itemData.isRecovery)
       item.fields.push({ name: 'recovery_node', value: 'true', type: 0 })
 
@@ -198,10 +202,14 @@ export const useVault = create<VaultState>((set, get) => ({
       item.login = { ...item.login, username: value }
     else if (field === 'password')
       item.login = { ...item.login, password: value }
+    else if (field === 'totp')
+      item.login = { ...item.login, totp: value }
     else if (field === 'uri') {
       const uris = item.login?.uris?.length ? [...item.login.uris] : [{ match: null, uri: '' }]
       uris[0] = { ...uris[0], uri: value }
       item.login = { ...item.login, uris }
+    } else if (field === 'notes') {
+      item.notes = value
     }
 
     items[idx] = item


### PR DESCRIPTION
## Summary
- extend chat create/edit functions to include `totp` and `notes`
- handle totp secrets like passwords in ChatInterface
- support totp and notes when creating or editing items in the vault

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6841b5a2bc0c832cbf298dd882896f58