### PR TITLE
Add lost access simulation

### DIFF
--- a/app-main/components/LostModal.tsx
+++ b/app-main/components/LostModal.tsx
@@ -1,0 +1,51 @@
+'use client'
+import { useGraph } from '@/contexts/GraphStore'
+import { useLostStore } from '@/contexts/LostStore'
+
+interface Props {
+  id: string
+  onClose: () => void
+}
+
+export default function LostModal({ id, onClose }: Props) {
+  const { nodes, edges } = useGraph()
+  const { markLost } = useLostStore()
+
+  const node = nodes.find(n => n.id === id)
+  if (!node) return null
+
+  const recoveryEdges = edges.filter(e => e.target === id && e.style?.stroke === '#8b5cf6')
+  const providerEdges = edges.filter(e => e.target === id && e.style?.stroke === '#0ea5e9')
+
+  const recoveryNodes = recoveryEdges.map(e => nodes.find(n => n.id === e.source)).filter(Boolean)
+  const providerNodes = providerEdges.map(e => nodes.find(n => n.id === e.source)).filter(Boolean)
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50" onClick={onClose}>
+      <div className="bg-white rounded-md shadow-md max-w-md w-full p-6" onClick={e => e.stopPropagation()}>
+        <h2 className="text-lg font-semibold mb-4">Lost Access to {node.data.label}</h2>
+        <p className="mb-2">These items may help you recover access:</p>
+        <ul className="list-disc list-inside space-y-1 mb-4">
+          {recoveryNodes.map((n: any) => (
+            <li key={n.id}>{n.data.label} (recovery)</li>
+          ))}
+          {providerNodes.map((n: any) => (
+            <li key={n.id}>{n.data.label} (2FA provider)</li>
+          ))}
+          {!recoveryNodes.length && !providerNodes.length && (
+            <li>No linked recovery methods</li>
+          )}
+        </ul>
+        <button
+          onClick={() => { markLost(id); onClose() }}
+          className="bg-red-600 text-white px-4 py-2 rounded mr-2"
+        >
+          Mark as Lost
+        </button>
+        <button onClick={onClose} className="bg-gray-300 px-4 py-2 rounded">
+          Close
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/app-main/components/VaultDiagram.tsx
+++ b/app-main/components/VaultDiagram.tsx
@@ -21,6 +21,7 @@ import { parseVault } from '@/lib/parseVault'
 import * as storage from '@/lib/storage'
 import EditItemModal from './EditItemModal'
 import VaultNode from './VaultNode'
+import LostModal from './LostModal'
 import { QuestionMarkCircleIcon } from '@heroicons/react/24/outline'
 
 const nodeTypes = { vault: VaultNode }
@@ -32,6 +33,7 @@ function DiagramContent() {
   const diagramRef = useRef<HTMLDivElement>(null)
   const [menu, setMenu] = useState<{x:number,y:number,id:string}|null>(null)
   const [editIndex, setEditIndex] = useState<number|null>(null)
+  const [lostId, setLostId] = useState<string|null>(null)
   const isInteractive = useStore((s) => s.nodesDraggable && s.nodesConnectable && s.elementsSelectable)
   const positionsRef = useRef<Record<string,{x:number,y:number}>>(storage.loadPositions())
 
@@ -154,10 +156,19 @@ function DiagramContent() {
           >
             Edit Item
           </li>
+          <li
+            className="px-3 py-1 cursor-pointer hover:bg-gray-100"
+            onClick={()=>{setLostId(menu.id);setMenu(null)}}
+          >
+            Lost Access
+          </li>
         </ul>
       )}
       {editIndex!==null && (
         <EditItemModal index={editIndex} onClose={()=>setEditIndex(null)} />
+      )}
+      {lostId && (
+        <LostModal id={lostId} onClose={()=>setLostId(null)} />
       )}
     </div>
   )

--- a/app-main/components/VaultNode.tsx
+++ b/app-main/components/VaultNode.tsx
@@ -2,13 +2,16 @@
 import { Handle, NodeProps, Position } from 'reactflow'
 
 import { useHoverStore } from '@/contexts/HoverStore'
+import { useLostStore } from '@/contexts/LostStore'
 
 export default function VaultNode({ id, data }: NodeProps) {
   const { hoveredId, setHoveredId } = useHoverStore()
+  const { lost } = useLostStore()
   const highlighted = hoveredId === id
+  const isLost = lost.includes(id)
   return (
     <div
-      className={`flex flex-col items-center gap-1 p-3 rounded-2xl shadow bg-white/90 backdrop-blur max-w-[9rem] ${highlighted ? 'ring-2 ring-indigo-500' : ''}`}
+      className={`flex flex-col items-center gap-1 p-3 rounded-2xl shadow bg-white/90 backdrop-blur max-w-[9rem] ${highlighted ? 'ring-2 ring-indigo-500' : ''} ${isLost ? 'border-2 border-red-500 opacity-60' : ''}`}
       onMouseEnter={() => setHoveredId(id)}
       onMouseLeave={() => setHoveredId(null)}
     >

--- a/app-main/contexts/LostStore.ts
+++ b/app-main/contexts/LostStore.ts
@@ -1,0 +1,14 @@
+'use client'
+import { create } from 'zustand'
+
+interface LostState {
+  lost: string[]
+  markLost: (id: string) => void
+  clearLost: (id: string) => void
+}
+
+export const useLostStore = create<LostState>((set) => ({
+  lost: [],
+  markLost: (id) => set((state) => ({ lost: Array.from(new Set([...state.lost, id])) })),
+  clearLost: (id) => set((state) => ({ lost: state.lost.filter((l) => l !== id) })),
+}))


### PR DESCRIPTION
## Summary
- add `LostStore` zustand store to track lost nodes
- add `LostModal` to display recovery options and mark nodes lost
- highlight lost nodes in `VaultNode`
- extend diagram context menu with `Lost Access` action

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6841baa763bc832c9bb58dc9d97f4196