### PR TITLE
Improve automatic item creation

### DIFF
--- a/app-main/components/ChatInterface.tsx
+++ b/app-main/components/ChatInterface.tsx
@@ -24,6 +24,9 @@ Always begin by asking whether the user has a Bitwarden or Vaultwarden account. 
 
 When the user provides the name of a service and an email address, automatically use the create_item function to add it to the vault before continuing the conversation.
 
+If no URL is specified for the service, infer a sensible default from the name
+(for example "instagram.com" for "Instagram").
+
 Each item has a custom field “vaultdiagram-id” that uniquely identifies it. Relationships are stored in two JSON based fields:
   • “vaultdiagram-recovery-map” with optional “recovers” and “recovered_by” arrays of vaultdiagram-id values.
   • “vaultdiagram-2fa-map” with a “providers” array referencing vaultdiagram-id values of recovery methods.
@@ -221,6 +224,16 @@ const FUNCTIONS = [
             setVault(updated)
             updateGraph(updated)
           }
+          const gmailItem = updated?.items?.find((i: any) =>
+            /gmail/i.test(i.name),
+          )
+          const follow = gmailItem
+            ? ` Is \"${gmailItem.name}\" the recovery for ${data.name}?`
+            : ` Do you want to add a recovery method for ${data.name}?`
+          setMessages((m) => [
+            ...m,
+            { role: 'assistant', content: `Item \"${data.name}\" added.` + follow },
+          ])
         } else if (name === 'edit_item') {
           const value =
             data.field === 'password' && !data.value && lastPassword.current

--- a/app-main/contexts/VaultStore.ts
+++ b/app-main/contexts/VaultStore.ts
@@ -1,6 +1,28 @@
 'use client'
 import { create } from 'zustand'
 
+// ---------------------------------------------------------------------------
+// Helper to guess a domain from a service name
+// ---------------------------------------------------------------------------
+const SERVICE_DOMAINS: Record<string, string> = {
+  instagram: 'instagram.com',
+  facebook: 'facebook.com',
+  gmail: 'gmail.com',
+  google: 'google.com',
+  linkedin: 'linkedin.com',
+  netflix: 'netflix.com',
+  twitter: 'twitter.com',
+}
+
+const guessDomainFromName = (name?: string): string | null => {
+  if (!name) return null
+  const key = name.trim().toLowerCase()
+  if (SERVICE_DOMAINS[key]) return SERVICE_DOMAINS[key]
+  const sanitized = key.replace(/[^a-z0-9]/g, '')
+  if (sanitized.length < 3) return null
+  return `${sanitized}.com`
+}
+
 interface VaultState {
   vault: any | null
   setVault: (v: any) => void
@@ -179,7 +201,9 @@ export const useVault = create<VaultState>((set, get) => ({
     if (itemData.username) item.login.username = itemData.username
     if (itemData.password) item.login.password = itemData.password
     if (itemData.totp) item.login.totp = itemData.totp
-    if (itemData.uri) item.login.uris = [{ uri: itemData.uri, match: null }]
+    const uriGuess = itemData.uri || `https://${guessDomainFromName(itemData.name) || ''}`
+    if (uriGuess && uriGuess !== 'https://')
+      item.login.uris = [{ uri: uriGuess, match: null }]
     if (itemData.notes) item.notes = itemData.notes
     if (itemData.isRecovery)
       item.fields.push({ name: 'recovery_node', value: 'true', type: 0 })


### PR DESCRIPTION
## Summary
- infer domain from service names when creating items
- mention URL inference in the system prompt
- confirm new items and suggest recovery mapping automatically

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6841bc0dfed0832ca66aed5ae58e11bf