### PR TITLE
Add grouping to sample vault

### DIFF
--- a/app-main/components/GroupNode.tsx
+++ b/app-main/components/GroupNode.tsx
@@ -1,0 +1,10 @@
+'use client'
+import { NodeProps } from 'reactflow'
+
+export default function GroupNode({ data }: NodeProps) {
+  return (
+    <div className="pointer-events-none w-full h-full rounded-lg border border-dashed border-slate-400 bg-slate-50 p-2">
+      <span className="text-xs font-semibold text-slate-700">{data.label}</span>
+    </div>
+  )
+}

--- a/app-main/components/VaultDiagram.tsx
+++ b/app-main/components/VaultDiagram.tsx
@@ -21,10 +21,11 @@ import { parseVault } from '@/lib/parseVault'
 import * as storage from '@/lib/storage'
 import EditItemModal from './EditItemModal'
 import VaultNode from './VaultNode'
+import GroupNode from './GroupNode'
 import LostModal from './LostModal'
 import { QuestionMarkCircleIcon } from '@heroicons/react/24/outline'
 
-const nodeTypes = { vault: VaultNode }
+const nodeTypes = { vault: VaultNode, group: GroupNode }
 
 function DiagramContent() {
   const { nodes, edges, setGraph } = useGraph()

--- a/app-main/lib/parseVault.ts
+++ b/app-main/lib/parseVault.ts
@@ -204,6 +204,59 @@ export const parseVault = (vault: any) => {
     if(pos) n.position = pos
   })
 
+  // -----------------------------------------------------------------------
+  // Group nodes based on folder information
+  // -----------------------------------------------------------------------
+  const folderDefs: Record<string,{name:string,parentId?:string}> = {}
+  ;(vault.folders||[]).forEach((f:any)=>{ folderDefs[f.id] = {name:f.name,parentId:f.parentId} })
+
+  const folderChildren: Record<string, Node[]> = {}
+  vault.items.forEach((item:any) => {
+    if(!item.folderId) return
+    const node = nodes.find(n => n.id === `item-${item.id}`)
+    if(!node) return
+    if(!folderChildren[item.folderId]) folderChildren[item.folderId] = []
+    folderChildren[item.folderId].push(node)
+  })
+
+  Object.entries(folderChildren).forEach(([fid,children])=>{
+    if(children.length===0) return
+    const def = folderDefs[fid] || {name:fid}
+    const minX = Math.min(...children.map(n=>n.position.x))
+    const minY = Math.min(...children.map(n=>n.position.y))
+    const maxX = Math.max(...children.map(n=>n.position.x))
+    const maxY = Math.max(...children.map(n=>n.position.y))
+    const pad = 40
+    const pos = {x:minX - pad, y:minY - pad}
+    const width = (maxX - minX) + stepX + pad*2
+    const height = (maxY - minY) + stepY + pad*2
+    const groupId = `folder-${fid}`
+
+    children.forEach(n=>{
+      n.position.x -= pos.x
+      n.position.y -= pos.y
+      ;(n as any).parentNode = groupId
+      ;(n as any).extent = 'parent'
+    })
+
+    nodes.push({
+      id: groupId,
+      type: 'group',
+      position: pos,
+      data: { label: def.name },
+      style: {
+        width,
+        height,
+        padding: 10,
+        border: '1px dashed #94a3b8',
+        background: '#f8fafc',
+        zIndex: -1,
+        pointerEvents: 'none',
+      },
+      ...(def.parentId ? { parentNode: `folder-${def.parentId}`, extent: 'parent' } : {}),
+    })
+  })
+
   return { nodes, edges }
 }
 

--- a/app-main/lib/sampleVault.ts
+++ b/app-main/lib/sampleVault.ts
@@ -6,6 +6,7 @@ export interface VaultItem {
   /** Bitwarden cipher type (1 = login) */
   type: number
   name: string
+  folderId?: string
   login: {
     username?: string
     password?: string
@@ -16,15 +17,23 @@ export interface VaultItem {
 
 export interface VaultData {
   items: VaultItem[]
+  folders?: { id: string; name: string; parentId?: string }[]
 }
 
 const templates: Record<TemplateName, VaultData> = {
   demo: {
+    folders: [
+      { id: 'vault.reipur.dk', name: 'vault.reipur.dk' },
+      { id: 'personal', name: 'Personal', parentId: 'vault.reipur.dk' },
+      { id: 'family', name: 'Family', parentId: 'vault.reipur.dk' },
+      { id: '2favault.reipur.dk', name: '2favault.reipur.dk' },
+    ],
     items: [
       {
         id: '5812e279-62f3-4cd6-a3b2-e01058b7c3fb',
         type: 1,
         name: 'Facebook',
+        folderId: 'personal',
         login: {
           username: 'john.doe@example.com',
           password: '',
@@ -33,13 +42,14 @@ const templates: Record<TemplateName, VaultData> = {
         fields: [
           { name: 'vaultdiagram-id', value: 'facebook-c3fb', type: 0 },
           { name: 'vaultdiagram-recovery-map', value: '{"recovered_by":["gmail-1863"]}', type: 0 },
-          { name: 'vaultdiagram-2fa-map', value: '{"providers":["sms-9604"]}', type: 0 },
+          { name: 'vaultdiagram-2fa-map', value: '{"providers":["sms-9604","facebook-2fa-1111"]}', type: 0 },
         ],
       },
       {
         id: 'af4a6fe3-9213-4b0f-8d83-0bf5cf251863',
         type: 1,
         name: 'Gmail',
+        folderId: 'personal',
         login: {
           username: 'john.doe@example.com',
           password: '',
@@ -55,6 +65,7 @@ const templates: Record<TemplateName, VaultData> = {
         id: 'a17ed712-5dcc-4b78-b9a7-9109a3567845',
         type: 1,
         name: 'LinkedIn',
+        folderId: 'personal',
         login: {
           username: 'john.doe@example.com',
           password: '',
@@ -63,13 +74,14 @@ const templates: Record<TemplateName, VaultData> = {
         fields: [
           { name: 'vaultdiagram-id', value: 'linkedin-7845', type: 0 },
           { name: 'vaultdiagram-recovery-map', value: '{"recovered_by":["gmail-1863"]}', type: 0 },
-          { name: 'vaultdiagram-2fa-map', value: '{"providers":["sms-9604","gmail-1863","phone-pixel-7a-2b11"]}', type: 0 },
+          { name: 'vaultdiagram-2fa-map', value: '{"providers":["sms-9604","gmail-1863","phone-pixel-7a-2b11","linkedin-2fa-2222"]}', type: 0 },
         ],
       },
       {
         id: 'f9e5bffb-7fdc-4ec0-ae19-390940c730a1',
         type: 1,
         name: 'Netflix',
+        folderId: 'family',
         login: {
           username: 'john.doe@example.com',
           password: '',
@@ -113,6 +125,7 @@ const templates: Record<TemplateName, VaultData> = {
         id: '5bdd19e4-9973-41a5-9b5f-08e54ec42431',
         type: 1,
         name: 'Vaultwarden Dev',
+        folderId: 'personal',
         login: {
           username: 'john.doe@example.com',
           password: '',
@@ -121,6 +134,26 @@ const templates: Record<TemplateName, VaultData> = {
         fields: [
           { name: 'vaultdiagram-id', value: 'vaultwarden-dev-2431', type: 0 },
           { name: 'vaultdiagram-recovery-map', value: '{"recovered_by":["gmail-1863"]}', type: 0 },
+        ],
+      },
+      {
+        id: '8cf2d705-2fa1-4c0e-a111-111111111111',
+        type: 1,
+        name: 'Facebook 2FA',
+        folderId: '2favault.reipur.dk',
+        login: {},
+        fields: [
+          { name: 'vaultdiagram-id', value: 'facebook-2fa-1111', type: 0 },
+        ],
+      },
+      {
+        id: '9df2d705-2fa1-4c0e-a222-222222222222',
+        type: 1,
+        name: 'LinkedIn 2FA',
+        folderId: '2favault.reipur.dk',
+        login: {},
+        fields: [
+          { name: 'vaultdiagram-id', value: 'linkedin-2fa-2222', type: 0 },
         ],
       },
     ],


### PR DESCRIPTION
## Summary
- enable folder-based grouping in diagram parsing
- add new GroupNode component
- show new node type in diagram
- update sample vault data with folders and 2FA entries

## Testing
- `npm install --ignore-scripts`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6841bf86f340832c89532e7dfa56565c