### PR TITLE
Add personal and organization vault options

### DIFF
--- a/app-main/components/ExportButton.tsx
+++ b/app-main/components/ExportButton.tsx
@@ -1,13 +1,17 @@
 'use client'
+import { useState } from 'react'
 import { useVault } from '@/contexts/VaultStore'
 import { saveVault } from '@/lib/storage'
+import { filterVaultByCategory, VaultCategory } from '@/lib/filterVault'
 
 export default function ExportButton() {
   const { vault } = useVault()
+  const [category, setCategory] = useState<VaultCategory>('personal')
   if (!vault) return null
 
   const onExport = () => {
-    const json = JSON.stringify(vault, null, 2)
+    const filtered = filterVaultByCategory(vault, category)
+    const json = JSON.stringify(filtered, null, 2)
     const blob = new Blob([json], { type: 'application/json' })
     const url = URL.createObjectURL(blob)
     const a = document.createElement('a')
@@ -19,11 +23,20 @@ export default function ExportButton() {
   }
 
   return (
-    <button
-      onClick={onExport}
-      className="px-4 py-2 bg-indigo-600 text-white rounded self-start"
-    >
-      Export Vault
-    </button>
+    <div className="flex flex-col items-start gap-2">
+      <div>
+        <label className="mr-2">Export</label>
+        <select value={category} onChange={e=>setCategory(e.target.value as VaultCategory)} className="border px-2 py-1">
+          <option value="personal">Personal</option>
+          <option value="organization">Organization</option>
+        </select>
+      </div>
+      <button
+        onClick={onExport}
+        className="px-4 py-2 bg-indigo-600 text-white rounded self-start"
+      >
+        Export Vault
+      </button>
+    </div>
   )
 }

--- a/app-main/components/TemplateZone.tsx
+++ b/app-main/components/TemplateZone.tsx
@@ -10,7 +10,8 @@ export default function TemplateZone({ onGenerate }:{ onGenerate:(v:any)=>void }
     <div className="border-2 border-dashed p-8 text-center flex flex-col gap-4">
       <span>Or generate a template:</span>
       <div className="flex justify-center gap-2">
-        <button onClick={() => generate('demo')} className="px-3 py-2 bg-indigo-600 text-white rounded">Demo</button>
+        <button onClick={() => generate('personal')} className="px-3 py-2 bg-indigo-600 text-white rounded">Personal</button>
+        <button onClick={() => generate('organization')} className="px-3 py-2 bg-indigo-600 text-white rounded">Organization</button>
       </div>
     </div>
   )

--- a/app-main/components/UploadZone.tsx
+++ b/app-main/components/UploadZone.tsx
@@ -1,21 +1,36 @@
 'use client'
-import { useCallback } from 'react'
+import { useCallback, useState } from 'react'
 import { useDropzone } from 'react-dropzone'
 import { saveVault } from '@/lib/storage'
+import { filterVaultByCategory, VaultCategory } from '@/lib/filterVault'
 
 export default function UploadZone({ onLoad }:{ onLoad:(json:any)=>void }){
+  const [category, setCategory] = useState<VaultCategory>('personal')
   const onDrop = useCallback((files:File[])=>{
     const file = files[0]
     file.text().then(txt=>{
-      try{ onLoad(JSON.parse(txt)); saveVault(txt) }
-      catch{ alert('Invalid export') }
+      try{
+        const data = JSON.parse(txt)
+        const filtered = filterVaultByCategory(data, category)
+        onLoad(filtered)
+        saveVault(JSON.stringify(filtered))
+      }catch{ alert('Invalid export') }
     })
-  },[onLoad])
+  },[onLoad, category])
   const {getRootProps,getInputProps,isDragActive}=useDropzone({onDrop,accept:{'application/json':['.json','.csv']}})
   return (
-    <div {...getRootProps()} className={`border-2 border-dashed p-8 text-center ${isDragActive?'bg-indigo-50':''}`}>
-      <input {...getInputProps()} />
-      Drop Bitwarden export here or click to select
+    <div>
+      <div {...getRootProps()} className={`border-2 border-dashed p-8 text-center${isDragActive?' bg-indigo-50':''}`}>
+        <input {...getInputProps()} />
+        Drop Bitwarden export here or click to select
+      </div>
+      <div className="mt-2 text-center">
+        <label className="mr-2">Import as</label>
+        <select value={category} onChange={e=>setCategory(e.target.value as VaultCategory)} className="border px-2 py-1">
+          <option value="personal">Personal</option>
+          <option value="organization">Organization</option>
+        </select>
+      </div>
     </div>
   )
 }

--- a/app-main/lib/filterVault.ts
+++ b/app-main/lib/filterVault.ts
@@ -1,0 +1,11 @@
+export type VaultCategory = 'personal' | 'organization'
+
+export function filterVaultByCategory(vault: any, category: VaultCategory) {
+  const items = (vault.items || []).filter((i: any) => {
+    const hasOrg = Boolean(i.organizationId)
+    return category === 'personal' ? !hasOrg : hasOrg
+  })
+  const folderIds = new Set(items.map((i: any) => i.folderId).filter(Boolean))
+  const folders = (vault.folders || []).filter((f: any) => folderIds.has(f.id))
+  return { ...vault, items, folders }
+}

--- a/app-main/lib/sampleVault.ts
+++ b/app-main/lib/sampleVault.ts
@@ -1,5 +1,5 @@
 
-export type TemplateName = 'demo'
+export type TemplateName = 'personal' | 'organization'
 
 export interface VaultItem {
   id: string
@@ -7,6 +7,7 @@ export interface VaultItem {
   type: number
   name: string
   folderId?: string
+  organizationId?: string
   login: {
     username?: string
     password?: string
@@ -21,9 +22,10 @@ export interface VaultData {
 }
 
 const templates: Record<TemplateName, VaultData> = {
-  demo: {
+  personal: {
     folders: [
-      { id: 'vault.reipur.dk', name: 'vault.reipur.dk' },
+      { id: 'personal', name: 'Personal' },
+      { id: 'vault.reipur.dk', name: 'vault.reipur.dk', parentId: 'personal' },
       { id: 'family', name: 'Family', parentId: 'vault.reipur.dk' },
       { id: '2favault.reipur.dk', name: '2favault.reipur.dk', parentId: 'vault.reipur.dk' },
     ],
@@ -153,6 +155,58 @@ const templates: Record<TemplateName, VaultData> = {
         login: {},
         fields: [
           { name: 'vaultdiagram-id', value: 'linkedin-2fa-2222', type: 0 },
+        ],
+      },
+    ],
+  },
+  organization: {
+    folders: [
+      { id: 'organization', name: 'Organization' },
+      { id: 'acme', name: 'Acme Corp', parentId: 'organization' },
+    ],
+    items: [
+      {
+        id: '11111111-2222-4333-8444-555555555555',
+        type: 1,
+        name: 'Slack',
+        folderId: 'acme',
+        organizationId: 'org-demo',
+        login: {
+          username: 'john.doe@acme.com',
+          password: '',
+          uris: [{ uri: 'https://slack.com', match: null }],
+        },
+        fields: [
+          { name: 'vaultdiagram-id', value: 'slack-org', type: 0 },
+          { name: 'vaultdiagram-recovery-map', value: '{"recovered_by":["yubikey-org"]}', type: 0 },
+        ],
+      },
+      {
+        id: '22222222-3333-4444-8555-666666666666',
+        type: 1,
+        name: 'GitHub',
+        folderId: 'acme',
+        organizationId: 'org-demo',
+        login: {
+          username: 'jdoe',
+          password: '',
+          uris: [{ uri: 'https://github.com', match: null }],
+        },
+        fields: [
+          { name: 'vaultdiagram-id', value: 'github-org', type: 0 },
+          { name: 'vaultdiagram-recovery-map', value: '{"recovered_by":["yubikey-org"]}', type: 0 },
+        ],
+      },
+      {
+        id: '33333333-4444-5555-8666-777777777777',
+        type: 1,
+        name: 'YubiKey',
+        folderId: 'acme',
+        organizationId: 'org-demo',
+        login: {},
+        fields: [
+          { name: 'vaultdiagram-id', value: 'yubikey-org', type: 0 },
+          { name: 'recovery_node', value: 'true', type: 0 },
         ],
       },
     ],


### PR DESCRIPTION
## Summary
- support `personal` and `organization` templates in the demo vault
- allow choosing which vault type to generate
- filter vault items on import and export

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6841c275d970832c81a89a3644106289