### PR TITLE
Update 2FA recovery icons in demo vault

### DIFF
--- a/app-main/lib/sampleVault.ts
+++ b/app-main/lib/sampleVault.ts
@@ -144,6 +144,12 @@ const templates: Record<TemplateName, VaultData> = {
         login: {},
         fields: [
           { name: 'vaultdiagram-id', value: 'facebook-2fa-1111', type: 0 },
+          {
+            name: 'vaultdiagram-logo-url',
+            value: 'https://logo.clearbit.com/facebook.com?size=80',
+            type: 0,
+          },
+          { name: 'vaultdiagram-nested-domain', value: '2fas.com', type: 0 },
         ],
       },
       {
@@ -154,6 +160,12 @@ const templates: Record<TemplateName, VaultData> = {
         login: {},
         fields: [
           { name: 'vaultdiagram-id', value: 'linkedin-2fa-2222', type: 0 },
+          {
+            name: 'vaultdiagram-logo-url',
+            value: 'https://logo.clearbit.com/linkedin.com?size=80',
+            type: 0,
+          },
+          { name: 'vaultdiagram-nested-domain', value: '2fas.com', type: 0 },
         ],
       },
     ],


### PR DESCRIPTION
## Summary
- show nested 2FA logos for demo vault tokens

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6841c3bd4658832cacc8a8ac356785c0