### PR TITLE
Remove minimap from diagram

### DIFF
--- a/app-main/components/VaultDiagram.tsx
+++ b/app-main/components/VaultDiagram.tsx
@@ -3,7 +3,6 @@ import React, { useCallback, useState, useEffect, useRef } from 'react'
 import ReactFlow, {
   Background,
   Controls,
-  MiniMap,
   ReactFlowProvider,
   applyNodeChanges,
   addEdge,
@@ -126,7 +125,6 @@ function DiagramContent() {
         fitView
       >
         <Background />
-        <MiniMap pannable />
         <Controls showInteractive />
       </ReactFlow>
       {/* Legend --------------------------------------------------------- */}


### PR DESCRIPTION
## Summary
- remove `MiniMap` from the React Flow diagram so the UI no longer shows a small map

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6841c6712de4832c87ae2bb355fbdbaf