### PR TITLE
Add shrinkable group boxes

### DIFF
--- a/app-main/lib/parseVault.ts
+++ b/app-main/lib/parseVault.ts
@@ -23,7 +23,7 @@ const logoFor = (domain?: string) =>
 // ---------------------------------------------------------------------------
 // parseVault – converts a Bitwarden export into nodes + edges for React Flow
 // ---------------------------------------------------------------------------
-export const parseVault = (vault: any) => {
+export const parseVault = (vault: any, shrinkGroups = false) => {
   const nodes: Node[] = []
   const edges: Edge[] = []
 
@@ -251,10 +251,10 @@ export const parseVault = (vault: any) => {
     const maxX = Math.max(...children.map((n) => n.position.x))
     const maxY = Math.max(...children.map((n) => n.position.y))
 
-    const pad = 40
+    const pad = shrinkGroups ? 10 : 40
     let pos = { x: minX - pad, y: minY - pad }
-    const width = maxX - minX + stepX + pad * 2
-    const height = maxY - minY + stepY + pad * 2
+    let width = maxX - minX + stepX + (shrinkGroups ? 0 : pad * 2)
+    let height = maxY - minY + stepY + (shrinkGroups ? 0 : pad * 2)
     const groupId = `folder-${fid}`
 
     const siblings = Object.values(groupNodes).filter(g => (g as any).parentNode === (def.parentId ? `folder-${def.parentId}` : undefined))
@@ -264,11 +264,19 @@ export const parseVault = (vault: any) => {
       pos.y += height + margin
     }
 
+    const offsetAbove = fid === '2favault.reipur.dk' ? height + margin : 0
+    pos.y -= offsetAbove
+    if (offsetAbove) {
+      children.forEach(n => {
+        n.position.y -= offsetAbove
+      })
+    }
+
     children.forEach((n) => {
       n.position.x -= pos.x
       n.position.y -= pos.y
       ;(n as any).parentNode = groupId
-      ;(n as any).extent = 'parent'
+      if(!shrinkGroups) (n as any).extent = 'parent'
     })
 
     const groupNode: Node = {

--- a/app-main/pages/vaultDiagram.tsx
+++ b/app-main/pages/vaultDiagram.tsx
@@ -7,7 +7,7 @@ import VersionHistoryModal from '@/components/VersionHistoryModal'
 import TemplateZone from '@/components/TemplateZone'
 import VaultItemList from '@/components/VaultItemList'
 import EditItemModal from '@/components/EditItemModal'
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { parseVault } from '@/lib/parseVault'
 import * as storage from '@/lib/storage'
 import { useGraph } from '@/contexts/GraphStore'
@@ -23,16 +23,23 @@ export default function Vault() {
   const [showList, setShowList] = useState(true)
   const [showChat, setShowChat] = useState(true)
   const [showHistory, setShowHistory] = useState(false)
+  const [shrinkGroups, setShrinkGroups] = useState(false)
 
 
   const { clear } = useHiddenStore()
 
   const handleLoad = (data: any) => {
     setVault(data)
-    setGraph(parseVault(data))
+    setGraph(parseVault(data, shrinkGroups))
     clear()
     storage.saveVault(JSON.stringify(data))
   }
+
+  useEffect(() => {
+    if (vault) {
+      setGraph(parseVault(vault, shrinkGroups))
+    }
+  }, [shrinkGroups])
 
   return (
     <div className="p-4 flex flex-col gap-4 mx-auto px-6">
@@ -53,6 +60,14 @@ export default function Vault() {
           >
             Version History
           </button>
+          <label className="flex items-center gap-1 text-sm">
+            <input
+              type="checkbox"
+              checked={shrinkGroups}
+              onChange={e => setShrinkGroups(e.target.checked)}
+            />
+            Shrink Categories
+          </label>
         </div>
       )}
       <div className="flex flex-col md:flex-row gap-4">


### PR DESCRIPTION
## Summary
- allow toggling of group shrinking in the vault diagram page
- support `shrinkGroups` option when parsing vault data
- reduce category box padding when shrinking and move 2favault box above services

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841ca519dac832c993d8b81f4b0d9af