### PR TITLE
Implement vault lost access toggle

### DIFF
--- a/app-main/components/ExportButton.tsx
+++ b/app-main/components/ExportButton.tsx
@@ -27,7 +27,7 @@ export default function ExportButton() {
       <div>
         <label className="mr-2">Export</label>
         <select value={category} onChange={e=>setCategory(e.target.value as VaultCategory)} className="border px-2 py-1">
-          <option value="personal">Personal</option>
+          <option value="personal">vault.reipur.dk</option>
           <option value="organization">Organization</option>
         </select>
       </div>

--- a/app-main/components/LostModal.tsx
+++ b/app-main/components/LostModal.tsx
@@ -9,7 +9,7 @@ interface Props {
 
 export default function LostModal({ id, onClose }: Props) {
   const { nodes, edges } = useGraph()
-  const { markLost } = useLostStore()
+  const { markLost, clearLost, lost } = useLostStore()
 
   const node = nodes.find(n => n.id === id)
   if (!node) return null
@@ -58,10 +58,14 @@ export default function LostModal({ id, onClose }: Props) {
         )}
 
         <button
-          onClick={() => { markLost(id); onClose() }}
+          onClick={() => {
+            if(lost.includes(id)) clearLost(id)
+            else markLost(id)
+            onClose()
+          }}
           className="bg-red-600 text-white px-4 py-2 rounded mr-2"
         >
-          Mark as Lost
+          {lost.includes(id) ? 'Have Access' : 'Mark as Lost'}
         </button>
         <button onClick={onClose} className="bg-gray-300 px-4 py-2 rounded">
           Close

--- a/app-main/components/TemplateZone.tsx
+++ b/app-main/components/TemplateZone.tsx
@@ -10,7 +10,7 @@ export default function TemplateZone({ onGenerate }:{ onGenerate:(v:any)=>void }
     <div className="border-2 border-dashed p-8 text-center flex flex-col gap-4">
       <span>Or generate a template:</span>
       <div className="flex justify-center gap-2">
-        <button onClick={() => generate('personal')} className="px-3 py-2 bg-indigo-600 text-white rounded">Personal</button>
+        <button onClick={() => generate('personal')} className="px-3 py-2 bg-indigo-600 text-white rounded">vault.reipur.dk</button>
         <button onClick={() => generate('organization')} className="px-3 py-2 bg-indigo-600 text-white rounded">Organization</button>
       </div>
     </div>

--- a/app-main/components/UploadZone.tsx
+++ b/app-main/components/UploadZone.tsx
@@ -27,7 +27,7 @@ export default function UploadZone({ onLoad }:{ onLoad:(json:any)=>void }){
       <div className="mt-2 text-center">
         <label className="mr-2">Import as</label>
         <select value={category} onChange={e=>setCategory(e.target.value as VaultCategory)} className="border px-2 py-1">
-          <option value="personal">Personal</option>
+          <option value="personal">vault.reipur.dk</option>
           <option value="organization">Organization</option>
         </select>
       </div>

--- a/app-main/components/VaultDiagram.tsx
+++ b/app-main/components/VaultDiagram.tsx
@@ -17,6 +17,7 @@ import { useGraph } from '@/contexts/GraphStore'
 import { useVault } from '@/contexts/VaultStore'
 import { useHiddenStore } from '@/contexts/HiddenStore'
 import { useLockedStore } from '@/contexts/LockedStore'
+import { useLostStore } from '@/contexts/LostStore'
 import { parseVault } from '@/lib/parseVault'
 import * as storage from '@/lib/storage'
 import EditItemModal from './EditItemModal'
@@ -31,6 +32,7 @@ function DiagramContent() {
   const { nodes, edges, setGraph } = useGraph()
   const { hidden } = useHiddenStore()
   const { locked } = useLockedStore()
+  const { lost, clearLost, markLost } = useLostStore()
   const { vault, addRecovery } = useVault()
   const diagramRef = useRef<HTMLDivElement>(null)
   const [menu, setMenu] = useState<{x:number,y:number,id:string}|null>(null)
@@ -166,9 +168,13 @@ function DiagramContent() {
           </li>
           <li
             className="px-3 py-1 cursor-pointer hover:bg-gray-100"
-            onClick={()=>{setLostId(menu.id);setMenu(null)}}
+            onClick={()=>{
+              if(lost.includes(menu.id)) clearLost(menu.id)
+              else setLostId(menu.id)
+              setMenu(null)
+            }}
           >
-            Lost Access
+            {lost.includes(menu.id) ? 'Have Access' : 'Lost Access'}
           </li>
         </ul>
       )}

--- a/app-main/components/VaultLostButton.tsx
+++ b/app-main/components/VaultLostButton.tsx
@@ -1,0 +1,26 @@
+'use client'
+import { useGraph } from '@/contexts/GraphStore'
+import { useLostStore } from '@/contexts/LostStore'
+
+export default function VaultLostButton(){
+  const { nodes } = useGraph()
+  const { lost, markAll, clearAll } = useLostStore()
+
+  const ids = nodes.map(n => n.id)
+  const allLost = ids.length > 0 && ids.every(id => lost.includes(id))
+
+  const toggle = () => {
+    if(allLost) clearAll()
+    else markAll(ids)
+  }
+
+  return (
+    <button
+      onClick={toggle}
+      className="bg-red-600 text-white px-4 py-2 rounded self-start"
+    >
+      {allLost ? 'Have Access to Vault' : 'Lost Access to Vault'}
+    </button>
+  )
+}
+

--- a/app-main/contexts/LostStore.ts
+++ b/app-main/contexts/LostStore.ts
@@ -5,10 +5,14 @@ interface LostState {
   lost: string[]
   markLost: (id: string) => void
   clearLost: (id: string) => void
+  markAll: (ids: string[]) => void
+  clearAll: () => void
 }
 
 export const useLostStore = create<LostState>((set) => ({
   lost: [],
   markLost: (id) => set((state) => ({ lost: Array.from(new Set([...state.lost, id])) })),
   clearLost: (id) => set((state) => ({ lost: state.lost.filter((l) => l !== id) })),
+  markAll: (ids) => set((state) => ({ lost: Array.from(new Set([...state.lost, ...ids])) })),
+  clearAll: () => set({ lost: [] })
 }))

--- a/app-main/lib/sampleVault.ts
+++ b/app-main/lib/sampleVault.ts
@@ -23,7 +23,7 @@ export interface VaultData {
 
 const personalTemplate: VaultData = {
     folders: [
-      { id: 'personal', name: 'Personal' },
+      { id: 'personal', name: 'vault.reipur.dk' },
       { id: 'vault.reipur.dk', name: 'vault.reipur.dk', parentId: 'personal' },
 
       { id: 'family', name: 'Family', parentId: 'vault.reipur.dk' },

--- a/app-main/pages/vaultDiagram.tsx
+++ b/app-main/pages/vaultDiagram.tsx
@@ -3,6 +3,7 @@ import DeleteZone from '@/components/DeleteZone'
 import VaultDiagram from '@/components/VaultDiagram'
 import ChatInterface from '@/components/ChatInterface'
 import ExportButton from '@/components/ExportButton'
+import VaultLostButton from '@/components/VaultLostButton'
 import VersionHistoryModal from '@/components/VersionHistoryModal'
 import TemplateZone from '@/components/TemplateZone'
 import VaultItemList from '@/components/VaultItemList'
@@ -54,6 +55,7 @@ export default function Vault() {
       {vault && (
         <div className="flex gap-2">
           <ExportButton />
+          <VaultLostButton />
           <button
             onClick={() => setShowHistory(true)}
             className="px-4 py-2 bg-indigo-600 text-white rounded self-start"


### PR DESCRIPTION
## Summary
- replace "Personal" label with `vault.reipur.dk`
- allow marking/unmarking items as lost directly from the modal and context menu
- add button to mark/unmark entire vault as lost

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68421c767f3c832c815ac300f56fba21