### PR TITLE
Show family organization in personal vault

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ To enable Google Analytics, copy `app-main/.env.local.example` to `app-main/.env
 
 The app is currently in an alpha stage. A small red **ALPHA** banner appears in the top-right corner of every page as a reminder.
 
+## Family Organization Items
+
+When you import or export a vault as *Personal*, items shared through a Bitwarden **family organization** are also included. Any organization with `Family` in its name is treated as part of the personal vault so the items appear alongside your own.
+
 ## Version History
 
 Every time the vault is saved a snapshot is appended to a local history stored in your browser. Click **Version History** next to the export button to restore earlier snapshots.

--- a/app-main/lib/filterVault.ts
+++ b/app-main/lib/filterVault.ts
@@ -1,9 +1,20 @@
 export type VaultCategory = 'personal' | 'organization'
 
 export function filterVaultByCategory(vault: any, category: VaultCategory) {
+  const familyOrgIds = new Set<string>()
+  if (category === 'personal') {
+    const orgs = (vault.organizations || []) as any[]
+    orgs.forEach(org => {
+      if (typeof org.name === 'string' && /family/i.test(org.name)) {
+        familyOrgIds.add(org.id)
+      }
+    })
+  }
+
   const items = (vault.items || []).filter((i: any) => {
     const hasOrg = Boolean(i.organizationId)
-    return category === 'personal' ? !hasOrg : hasOrg
+    const inFamily = i.organizationId && familyOrgIds.has(i.organizationId)
+    return category === 'personal' ? !hasOrg || inFamily : hasOrg && !inFamily
   })
   const folderIds = new Set(items.map((i: any) => i.folderId).filter(Boolean))
   const folders = (vault.folders || []).filter((f: any) => folderIds.has(f.id))


### PR DESCRIPTION
## Summary
- include family organization data when filtering for personal items
- document that family organization items appear inside the personal vault

## Testing
- `npx tsc --noEmit` *(fails: Cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_68421cbab8d8832caf592a013ef3ce2b