### PR TITLE
Fix 2FA vault group placement

### DIFF
--- a/app-main/lib/parseVault.ts
+++ b/app-main/lib/parseVault.ts
@@ -264,7 +264,10 @@ export const parseVault = (vault: any, shrinkGroups = false) => {
       pos.y += height + margin
     }
 
-    const offsetAbove = fid === '2favault.reipur.dk' ? height + margin : 0
+    let offsetAbove = 0
+    if (fid === '2favault.reipur.dk') {
+      offsetAbove = pos.y + height + margin
+    }
     pos.y -= offsetAbove
     if (offsetAbove) {
       children.forEach(n => {


### PR DESCRIPTION
## Summary
- tweak positioning logic so `2favault.reipur.dk` appears above other groups

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68421c8ae164832c8d2c6af858218080