### PR TITLE
Fix 2favault group layout

### DIFF
--- a/app-main/lib/parseVault.ts
+++ b/app-main/lib/parseVault.ts
@@ -264,16 +264,11 @@ export const parseVault = (vault: any, shrinkGroups = false) => {
       pos.y += height + margin
     }
 
-    let offsetAbove = 0
-    if (fid === '2favault.reipur.dk') {
-      offsetAbove = pos.y + height + margin
-    }
-    pos.y -= offsetAbove
-    if (offsetAbove) {
-      children.forEach(n => {
-        n.position.y -= offsetAbove
-      })
-    }
+    // Ensure all groups behave consistently when moved.
+    // Previously the special 2favault.reipur.dk category was moved above
+    // everything else via a negative offset. This caused its child nodes to
+    // drift outside the box when dragging the group.  Removing the offset keeps
+    // the children inside the container during interactive moves.
 
     children.forEach((n) => {
       n.position.x -= pos.x


### PR DESCRIPTION
## Summary
- remove negative offset handling for the `2favault.reipur.dk` folder

## Testing
- `npm install` *(fails: next not found due to missing dependencies)*


------
https://chatgpt.com/codex/tasks/task_e_6843046453bc832cb641e8e33624804b