### PR TITLE
Fix shrink categories layout

### DIFF
--- a/app-main/lib/parseVault.ts
+++ b/app-main/lib/parseVault.ts
@@ -253,8 +253,8 @@ export const parseVault = (vault: any, shrinkGroups = false) => {
 
     const pad = shrinkGroups ? 10 : 40
     let pos = { x: minX - pad, y: minY - pad }
-    let width = maxX - minX + stepX + (shrinkGroups ? 0 : pad * 2)
-    let height = maxY - minY + stepY + (shrinkGroups ? 0 : pad * 2)
+    let width = maxX - minX + stepX + pad * 2
+    let height = maxY - minY + stepY + pad * 2
     const groupId = `folder-${fid}`
 
     const siblings = Object.values(groupNodes).filter(g => (g as any).parentNode === (def.parentId ? `folder-${def.parentId}` : undefined))


### PR DESCRIPTION
## Summary
- adjust group node width and height so shrink mode only alters padding

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68430ce988b4832c92ae54207fcf3e7e