### PR TITLE
Enable resizing of group nodes

### DIFF
--- a/app-main/components/GroupNode.tsx
+++ b/app-main/components/GroupNode.tsx
@@ -1,9 +1,12 @@
 'use client'
 import { NodeProps } from 'reactflow'
+import { NodeResizer } from '@reactflow/node-resizer'
+import '@reactflow/node-resizer/dist/style.css'
 
-export default function GroupNode({ data }: NodeProps) {
+export default function GroupNode({ data, selected }: NodeProps) {
   return (
-    <div className="w-full h-full rounded-lg border border-dashed border-slate-400 bg-slate-50 p-2 cursor-move">
+    <div className="relative w-full h-full rounded-lg border border-dashed border-slate-400 bg-slate-50 p-2 cursor-move">
+      <NodeResizer color="#4f46e5" isVisible={selected} minWidth={100} minHeight={80} />
       <span className="text-xs font-semibold text-slate-700">{data.label}</span>
     </div>
   )

--- a/app-main/package.json
+++ b/app-main/package.json
@@ -25,6 +25,7 @@
     "react-dom": "^19.0.0",
     "react-dropzone": "^14.3.8",
     "reactflow": "^11.11.4",
+    "@reactflow/node-resizer": "^2.2.14",
     "zustand": "^5.0.5"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- allow group nodes to be resized via NodeResizer
- include `@reactflow/node-resizer` dependency

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6843144a1a10832c8d1140cea77e0786