### PR TITLE
Fix lingering edges when shrinking categories

### DIFF
--- a/app-main/components/VaultDiagram.tsx
+++ b/app-main/components/VaultDiagram.tsx
@@ -205,8 +205,15 @@ function DiagramContent() {
   )
 
   const visibleNodes = nodesWithLock.filter(n => !hidden.includes(n.id))
+  const validNodeIds = new Set(visibleNodes.map(n => n.id))
   const visibleEdges = edges
-    .filter(e => !hidden.includes(e.source) && !hidden.includes(e.target))
+    .filter(
+      e =>
+        validNodeIds.has(e.source) &&
+        validNodeIds.has(e.target) &&
+        !hidden.includes(e.source) &&
+        !hidden.includes(e.target),
+    )
     .map(e =>
       hoveredEdgeId === e.id ? { ...e, animated: true } : { ...e, animated: false }
     )


### PR DESCRIPTION
## Summary
- ensure VaultDiagram filters edges by existing nodes

## Testing
- `npm test --silent` *(fails: missing test script)*

------
https://chatgpt.com/codex/tasks/task_e_6843193c3688832cbbbd963f7dae4b9d