### PR TITLE
Remove nested beginner template folder

### DIFF
--- a/app-main/lib/sampleVault.ts
+++ b/app-main/lib/sampleVault.ts
@@ -29,9 +29,7 @@ const personalTemplate: VaultData = {
     organizations: [{ id: 'family-org', name: 'Family (organization)' }],
     folders: [
       { id: 'personal', name: 'Beginner Template' },
-      { id: 'vault.reipur.dk', name: 'Beginner Template', parentId: 'personal' },
-
-      { id: 'family', name: 'Family', parentId: 'vault.reipur.dk' },
+      { id: 'family', name: 'Family', parentId: 'personal' },
       { id: '2favault.reipur.dk', name: '2favault.reipur.dk' },
     ],
     items: [


### PR DESCRIPTION
## Summary
- drop redundant `Beginner Template` folder in sample vault

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68431a087158832c99b3875aeddae5d2