### PR TITLE
Add encryption for hidden vault items

### DIFF
--- a/app-main/components/ExportButton.tsx
+++ b/app-main/components/ExportButton.tsx
@@ -1,11 +1,13 @@
 'use client'
 import { useState } from 'react'
 import { useVault } from '@/contexts/VaultStore'
+import { useHiddenStore } from '@/contexts/HiddenStore'
 import { saveVault } from '@/lib/storage'
 import { filterVaultByCategory, VaultCategory } from '@/lib/filterVault'
 
 export default function ExportButton() {
   const { vault } = useVault()
+  const { key } = useHiddenStore()
   const [category, setCategory] = useState<VaultCategory>('personal')
   if (!vault) return null
 
@@ -20,6 +22,7 @@ export default function ExportButton() {
     a.click()
     URL.revokeObjectURL(url)
     saveVault(json)
+    alert(`Decrypt key: ${key}`)
   }
 
   return (

--- a/app-main/components/VaultItemList.tsx
+++ b/app-main/components/VaultItemList.tsx
@@ -76,18 +76,18 @@ export default function VaultItemList({ onEdit, onClose, onCreate }: Props) {
     )
   }
 
-  const toggleHideSelected = () => {
+  const toggleHideSelected = async () => {
     if (!items.length) return
     const ids = selected.map(i => `item-${items[i].id}`)
     const shouldHide = ids.some(id => !hidden.includes(id))
-    if (shouldHide) hide(ids)
-    else unhide(ids)
+    if (shouldHide) await hide(ids)
+    else await unhide(ids)
     setSelected([])
   }
 
-  const toggleVisibility = (id: string) => {
-    if (hidden.includes(id)) unhide([id])
-    else hide([id])
+  const toggleVisibility = async (id: string) => {
+    if (hidden.includes(id)) await unhide([id])
+    else await hide([id])
   }
 
   const toggleLock = (id: string) => {
@@ -98,12 +98,12 @@ export default function VaultItemList({ onEdit, onClose, onCreate }: Props) {
   const idsForVault = (name: string) =>
     items.filter((it: any) => (it.vault || 'None') === name).map((it: any) => `item-${it.id}`)
 
-  const toggleVaultVisibility = (name: string) => {
+  const toggleVaultVisibility = async (name: string) => {
     const ids = idsForVault(name)
     if (!ids.length) return
     const shouldHide = ids.some(id => !hidden.includes(id))
-    if (shouldHide) hide(ids)
-    else unhide(ids)
+    if (shouldHide) await hide(ids)
+    else await unhide(ids)
   }
 
   const toggleVaultLock = (name: string) => {

--- a/app-main/contexts/HiddenStore.ts
+++ b/app-main/contexts/HiddenStore.ts
@@ -1,16 +1,37 @@
 'use client'
 import { create } from 'zustand'
+import { generateKey } from '../lib/hiddenCrypto'
+import { useVault } from './VaultStore'
 
 interface HiddenState {
   hidden: string[]
-  hide: (ids: string[]) => void
-  unhide: (ids: string[]) => void
+  key: string
+  hide: (ids: string[]) => Promise<void>
+  unhide: (ids: string[]) => Promise<void>
   clear: () => void
+  regenerateKey: () => void
 }
-
-export const useHiddenStore = create<HiddenState>((set) => ({
-  hidden: [],
-  hide: (ids) => set(state => ({ hidden: Array.from(new Set([...state.hidden, ...ids])) })),
-  unhide: (ids) => set(state => ({ hidden: state.hidden.filter(id => !ids.includes(id)) })),
-  clear: () => set({ hidden: [] })
-}))
+export const useHiddenStore = create<HiddenState>((set, get) => {
+  let stored = ''
+  if (typeof localStorage !== 'undefined') stored = localStorage.getItem('hidden-key') || ''
+  const key = stored || generateKey()
+  if (!stored && typeof localStorage !== 'undefined') localStorage.setItem('hidden-key', key)
+  return {
+    hidden: [],
+    key,
+    hide: async (ids) => {
+      await useVault.getState().secureItems(ids, get().key)
+      set(state => ({ hidden: Array.from(new Set([...state.hidden, ...ids])) }))
+    },
+    unhide: async (ids) => {
+      await useVault.getState().revealItems(ids, get().key)
+      set(state => ({ hidden: state.hidden.filter(id => !ids.includes(id)) }))
+    },
+    clear: () => set({ hidden: [] }),
+    regenerateKey: () => {
+      const newKey = generateKey()
+      if (typeof localStorage !== 'undefined') localStorage.setItem('hidden-key', newKey)
+      set({ key: newKey })
+    },
+  }
+})

--- a/app-main/lib/hiddenCrypto.ts
+++ b/app-main/lib/hiddenCrypto.ts
@@ -1,0 +1,33 @@
+import { base64ToBytes } from './vaultCrypto'
+
+export const bytesToBase64 = (b: Uint8Array): string => Buffer.from(b).toString('base64')
+export const utf8ToBytes = (s: string): Uint8Array => new TextEncoder().encode(s)
+export const bytesToUtf8 = (b: Uint8Array): string => new TextDecoder().decode(b)
+
+export const generateKey = (): string => {
+  const arr = new Uint8Array(32)
+  globalThis.crypto.getRandomValues(arr)
+  return bytesToBase64(arr)
+}
+
+const subtle: SubtleCrypto = (globalThis.crypto as any).subtle
+
+export async function encryptString(plain: string, keyB64: string): Promise<string> {
+  const keyBytes = base64ToBytes(keyB64)
+  const key = await subtle.importKey('raw', keyBytes, 'AES-GCM', false, ['encrypt'])
+  const iv = globalThis.crypto.getRandomValues(new Uint8Array(12))
+  const ct = new Uint8Array(
+    await subtle.encrypt({ name: 'AES-GCM', iv }, key, utf8ToBytes(plain))
+  )
+  return `${bytesToBase64(iv)}:${bytesToBase64(ct)}`
+}
+
+export async function decryptString(enc: string, keyB64: string): Promise<string> {
+  const [ivB64, ctB64] = enc.split(':')
+  const iv = base64ToBytes(ivB64)
+  const ct = base64ToBytes(ctB64)
+  const keyBytes = base64ToBytes(keyB64)
+  const key = await subtle.importKey('raw', keyBytes, 'AES-GCM', false, ['decrypt'])
+  const pt = new Uint8Array(await subtle.decrypt({ name: 'AES-GCM', iv }, key, ct))
+  return bytesToUtf8(pt)
+}

--- a/app-main/pages/vaultDiagram.tsx
+++ b/app-main/pages/vaultDiagram.tsx
@@ -27,12 +27,13 @@ export default function Vault() {
   const [shrinkGroups, setShrinkGroups] = useState(false)
 
 
-  const { clear } = useHiddenStore()
+  const { clear, regenerateKey } = useHiddenStore()
 
   const handleLoad = (data: any) => {
     setVault(data)
     setGraph(parseVault(data, shrinkGroups))
     clear()
+    regenerateKey()
     storage.saveVault(JSON.stringify(data))
   }
 


### PR DESCRIPTION
## Summary
- encrypt hidden item fields using AES-GCM
- manage encryption key and hide/unhide logic in `HiddenStore`
- export decrypt key when exporting vault
- reset encryption key on vault upload

## Testing
- `npm run build` *(fails: `npm` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68431b73f8f0832c94dcb2a51981b205