### PR TITLE
Add vault selection to export

### DIFF
--- a/app-main/components/ExportButton.tsx
+++ b/app-main/components/ExportButton.tsx
@@ -2,15 +2,15 @@
 import { useState } from 'react'
 import { useVault } from '@/contexts/VaultStore'
 import { saveVault } from '@/lib/storage'
-import { filterVaultByCategory, VaultCategory } from '@/lib/filterVault'
+import { filterVaultByName, VaultName } from '@/lib/filterVault'
 
 export default function ExportButton() {
   const { vault } = useVault()
-  const [category, setCategory] = useState<VaultCategory>('personal')
+  const [selected, setSelected] = useState<VaultName>('My Vault')
   if (!vault) return null
 
   const onExport = () => {
-    const filtered = filterVaultByCategory(vault, category)
+    const filtered = filterVaultByName(vault, selected)
     const json = JSON.stringify(filtered, null, 2)
     const blob = new Blob([json], { type: 'application/json' })
     const url = URL.createObjectURL(blob)
@@ -26,9 +26,14 @@ export default function ExportButton() {
     <div className="flex flex-col items-start gap-2">
       <div>
         <label className="mr-2">Export</label>
-        <select value={category} onChange={e=>setCategory(e.target.value as VaultCategory)} className="border px-2 py-1">
-          <option value="personal">Beginner Template</option>
-          <option value="organization">Organization</option>
+        <select
+          value={selected}
+          onChange={e => setSelected(e.target.value as VaultName)}
+          className="border px-2 py-1"
+        >
+          <option value="My Vault">My Vault</option>
+          <option value="Family">Family</option>
+          <option value="2favault">2favault</option>
         </select>
       </div>
       <button

--- a/app-main/lib/filterVault.ts
+++ b/app-main/lib/filterVault.ts
@@ -20,3 +20,24 @@ export function filterVaultByCategory(vault: any, category: VaultCategory) {
   const folders = (vault.folders || []).filter((f: any) => folderIds.has(f.id))
   return { ...vault, items, folders }
 }
+
+export type VaultName = 'My Vault' | 'Family' | '2favault'
+
+export function filterVaultByName(vault: any, name: VaultName) {
+  let items: any[] = []
+  if (name === '2favault') {
+    items = (vault.items || []).filter(
+      (i: any) => i.folderId === '2favault.reipur.dk',
+    )
+  } else {
+    const needle = name === 'Family' ? 'Family (organization)' : name
+    items = (vault.items || []).filter((i: any) => i.vault === needle)
+  }
+  const folderIds = new Set(items.map((i: any) => i.folderId).filter(Boolean))
+  const folders = (vault.folders || []).filter((f: any) => folderIds.has(f.id))
+  const orgIds = new Set(items.map((i: any) => i.organizationId).filter(Boolean))
+  const organizations = (vault.organizations || []).filter((o: any) =>
+    orgIds.has(o.id),
+  )
+  return { ...vault, items, folders, organizations }
+}


### PR DESCRIPTION
## Summary
- allow exporting a specific vault
- new `filterVaultByName` helper

## Testing
- `npm --prefix app-main run build` *(fails: Parameter 'id' implicitly has an 'any' type)*

------
https://chatgpt.com/codex/tasks/task_e_68431ba37ec4832c8a1e2e9448c58a2e