### PR TITLE
Fix folderChildren push on parseVault

### DIFF
--- a/app-main/lib/parseVault.ts
+++ b/app-main/lib/parseVault.ts
@@ -333,6 +333,9 @@ export const parseVault = (vault: any, shrinkGroups = false) => {
     groupNodes[fid] = groupNode
 
     if (def.parentId) {
+      if (!folderChildren[def.parentId]) {
+        folderChildren[def.parentId] = []
+      }
       folderChildren[def.parentId].push(groupNode)
     }
   })


### PR DESCRIPTION
## Summary
- guard against missing parent folder when grouping nodes in `parseVault`

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68431c625d3c832c99925edf477e34d7