### PR TITLE
Make Supabase optional

### DIFF
--- a/app-main/lib/supabaseClient.ts
+++ b/app-main/lib/supabaseClient.ts
@@ -1,7 +1,10 @@
 // lib/supabaseClient.ts
-import { createClient } from '@supabase/supabase-js';
+import { createClient } from '@supabase/supabase-js'
 
-export const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-);
+export const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+export const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+export const supabaseConfigured = !!supabaseUrl && !!supabaseAnonKey
+
+export const supabase = supabaseConfigured
+  ? createClient(supabaseUrl!, supabaseAnonKey!)
+  : null

--- a/app-main/middleware.ts
+++ b/app-main/middleware.ts
@@ -1,8 +1,13 @@
 import { createMiddlewareClient } from '@supabase/auth-helpers-nextjs'
 import { NextResponse, type NextRequest } from 'next/server'
+import { supabaseConfigured } from '@/lib/supabaseClient'
 
 export async function middleware(req: NextRequest) {
   const res  = NextResponse.next()
+  if (!supabaseConfigured) {
+    return res
+  }
+
   const supa = createMiddlewareClient({ req, res })
   const {
     data: { session },

--- a/app-main/pages/_app.tsx
+++ b/app-main/pages/_app.tsx
@@ -2,8 +2,9 @@
 import '../styles/globals.css'
 import type { AppProps } from 'next/app'
 import { useEffect, useState } from 'react'
-import { createBrowserSupabaseClient } from '@supabase/auth-helpers-nextjs'
+import { createPagesBrowserClient } from '@supabase/auth-helpers-nextjs'
 import { SessionContextProvider } from '@supabase/auth-helpers-react'
+import { supabaseConfigured } from '@/lib/supabaseClient'
 import { useRouter } from 'next/router'
 import { pageview } from '@/lib/analytics'
 import { useGraph } from '@/contexts/GraphStore'
@@ -17,7 +18,9 @@ export default function App({ Component, pageProps }: AppProps) {
   const { setGraph } = useGraph()
   const { setVault } = useVault()
   const router = useRouter()
-  const [supabase] = useState(() => createBrowserSupabaseClient())
+  const [supabase] = useState(() =>
+    supabaseConfigured ? createPagesBrowserClient() : null
+  )
   useEffect(() => {
     const raw = loadVault()
     if (raw) {
@@ -33,12 +36,20 @@ export default function App({ Component, pageProps }: AppProps) {
       router.events.off('routeChangeComplete', handleRouteChange)
     }
   }, [router])
-  return (
-    <SessionContextProvider supabaseClient={supabase}>
+  const content = (
+    <>
       <AlphaBanner />
       <Header />
       <Component {...pageProps} />
+    </>
+  )
+
+  return supabaseConfigured ? (
+    <SessionContextProvider supabaseClient={supabase!}>
+      {content}
     </SessionContextProvider>
+  ) : (
+    content
   )
 
 }

--- a/app-main/pages/api/invoice.tsx
+++ b/app-main/pages/api/invoice.tsx
@@ -1,11 +1,16 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 import { createServerSupabaseClient } from '@supabase/auth-helpers-nextjs'
+import { supabaseConfigured } from '@/lib/supabaseClient'
 import { InvoicePDF } from '@/templates/InvoicePDF'
 import { renderToStream } from '@react-pdf/renderer'
 import React from 'react'
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') return res.status(405).end()
+  if (!supabaseConfigured) {
+    return res.status(501).json({ error: 'Supabase not configured' })
+  }
+
   const supa = createServerSupabaseClient({ req, res })
   const { data: { session } } = await supa.auth.getSession()
   if (!session) return res.status(401).json({ error: 'no session' })

--- a/app-main/pages/invoice.tsx
+++ b/app-main/pages/invoice.tsx
@@ -2,8 +2,17 @@ import { useSessionContext } from '@supabase/auth-helpers-react'
 import { useForm, useFieldArray } from 'react-hook-form'
 import { useState } from 'react'
 import currency from 'currency.js'
+import { supabaseConfigured } from '@/lib/supabaseClient'
 
 export default function InvoicePage(){
+  if (!supabaseConfigured) {
+    return (
+      <div className="max-w-3xl mx-auto p-4">
+        <p>Supabase is not configured.</p>
+      </div>
+    )
+  }
+
   const { session } = useSessionContext()
   const { register, control, handleSubmit, watch } = useForm({
     defaultValues:{

--- a/app-main/pages/login.tsx
+++ b/app-main/pages/login.tsx
@@ -1,8 +1,17 @@
 import { useSupabaseClient } from '@supabase/auth-helpers-react'
 import { useState } from 'react'
 import { useRouter } from 'next/router'
+import { supabaseConfigured } from '@/lib/supabaseClient'
 
 export default function Login() {
+  if (!supabaseConfigured) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <p className="p-4 bg-white rounded shadow">Supabase is not configured.</p>
+      </div>
+    )
+  }
+
   const supabase = useSupabaseClient()
   const router   = useRouter()
   const [email, setEmail] = useState('')


### PR DESCRIPTION
## Summary
- check if Supabase env vars are defined
- avoid creating a client when Supabase isn't configured
- show helpful messages in login and invoice pages
- skip Supabase logic in middleware and API routes
- use `createPagesBrowserClient`

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68682ba2a668832c9720aa5585c74c15