### PR TITLE
feat: share vault items panel

### DIFF
--- a/app-main/components/VaultItemList.tsx
+++ b/app-main/components/VaultItemList.tsx
@@ -29,6 +29,9 @@ const domainFrom = (raw?: string) => {
   }
 }
 
+const logoFor = (domain?: string) =>
+  domain ? `https://logo.clearbit.com/${domain}?size=80` : '/img/default.svg'
+
 
 export default function VaultItemList({ onEdit, onClose, onCreate }: Props) {
   const { vault } = useVault()
@@ -188,7 +191,10 @@ export default function VaultItemList({ onEdit, onClose, onCreate }: Props) {
               const item = items[index]
               const uri = item.login?.uris?.[0]?.uri
               const domain = domainFrom(uri)
-              const logo = `https://www.google.com/s2/favicons?domain=${domain || 'example.com'}`
+              const customLogo = item.fields?.find(
+                (f: any) => f.name === 'vaultdiagram-logo-url',
+              )?.value
+              const logo = customLogo || logoFor(domain)
               const isRecovery = item.fields?.some(
                 (f: any) =>
                   f.name === 'recovery_node' &&

--- a/app-main/pages/about.tsx
+++ b/app-main/pages/about.tsx
@@ -1,9 +1,14 @@
 // pages/about.tsx
+import VaultItemList from '@/components/VaultItemList'
+
 export default function About() {
   return (
-    <div className="p-10">
-      <h1 className="text-3xl font-semibold">About Victor Reipur</h1>
-      <p className="mt-4 text-lg">This is a placeholder for about page content.</p>
+    <div className="p-10 flex gap-8">
+      <div className="flex-1">
+        <h1 className="text-3xl font-semibold">About Victor Reipur</h1>
+        <p className="mt-4 text-lg">This is a placeholder for about page content.</p>
+      </div>
+      <VaultItemList onEdit={() => {}} />
     </div>
-  );
+  )
 }

--- a/app-main/pages/vaultOnboarding.tsx
+++ b/app-main/pages/vaultOnboarding.tsx
@@ -3,6 +3,7 @@ import Head from 'next/head'
 import { useVault } from '@/contexts/VaultStore'
 import { useGraph } from '@/contexts/GraphStore'
 import { parseVault } from '@/lib/parseVault'
+import VaultItemList from '@/components/VaultItemList'
 import * as storage from '@/lib/storage'
 import { MagnifyingGlassIcon, PlusIcon, CheckIcon } from '@heroicons/react/24/solid'
 
@@ -82,6 +83,13 @@ export default function VaultOnboarding() {
       console.error('Error saving vault items to localStorage:', error)
     }
   }, [vaultItems])
+
+  // Sync local items with global stores so other pages stay updated
+  useEffect(() => {
+    const data = { items: vaultItems }
+    setVault(data)
+    setGraph(parseVault(data))
+  }, [vaultItems, setVault, setGraph])
 
   // Filter services based on search query
   const filteredServices = commonServices.filter(service =>
@@ -350,7 +358,7 @@ export default function VaultOnboarding() {
                     </span>
                   </h3>
                 </div>
-                <div className="p-4 max-h-96 overflow-y-auto">
+                <div className="p-4">
                   {vaultItems.length === 0 ? (
                     <div className="text-center py-8 text-gray-500">
                       <div className="text-4xl mb-3">🔐</div>
@@ -358,36 +366,9 @@ export default function VaultOnboarding() {
                       <p className="text-xs mt-1">Click on services to add them to your vault</p>
                     </div>
                   ) : (
-                    <div className="space-y-2">
-                      {vaultItems.map((item, index) => {
-                        const service = [...commonServices, ...suggestedServices].find(s => 
-                          s.name.toLowerCase() === item.name.toLowerCase()
-                        )
-                        return (
-                          <div key={item.id} className="flex items-center gap-3 p-3 bg-gray-50 rounded-lg">
-                            <img 
-                              src={service?.icon || `https://www.google.com/s2/favicons?domain=${item.name.toLowerCase()}.com&sz=32`}
-                              alt={item.name}
-                              className="w-6 h-6"
-                            />
-                            <div className="flex-1">
-                              <span className="text-sm font-medium text-gray-900">{item.name}</span>
-                              <div className="text-xs text-gray-500">Login item</div>
-                            </div>
-                            <button
-                              onClick={() => removeServiceFromVault(item.name)}
-                              className="text-red-500 hover:text-red-700 text-sm"
-                              title="Remove from vault"
-                            >
-                              ×
-                            </button>
-                          </div>
-                        )
-                      })}
-                    </div>
+                    <VaultItemList onEdit={() => {}} />
                   )}
                 </div>
-                
                 {vaultItems.length > 0 && (
                   <div className="p-4 border-t border-gray-200">
                     <button

--- a/app-main/pages/vaultUpload.tsx
+++ b/app-main/pages/vaultUpload.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import * as storage from '@/lib/storage';
+import VaultItemList from '@/components/VaultItemList';
 
 interface Account {
   account: string;
@@ -100,12 +101,13 @@ export default function VaultUpload() {
   };
 
   return (
-    <div className="p-8 max-w-6xl mx-auto">
-      <h1 className="text-2xl font-bold mb-6">Vault Upload</h1>
-      
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
-        {/* Upload Section */}
-        <div>
+    <div className="p-8 max-w-6xl mx-auto flex gap-8">
+      <div className="flex-1">
+        <h1 className="text-2xl font-bold mb-6">Vault Upload</h1>
+
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
+          {/* Upload Section */}
+          <div>
           <h2 className="text-xl font-semibold mb-4">Upload New File</h2>
           <form onSubmit={handleSubmit} className="space-y-4">
             <div>
@@ -216,7 +218,9 @@ export default function VaultUpload() {
             </button>
           )}
         </div>
+        </div>
       </div>
+      <VaultItemList onEdit={() => {}} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- show VaultItemList panel on onboarding, upload, and about pages
- reuse logo URLs for vault items so pictures match React Flow diagram
- sync onboarding selections with global vault store

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c1691f8704832cb83cab9eda00cf7a