### PR TITLE
Remove sample vault from diagram page

### DIFF
--- a/app-main/pages/vaultDiagram.tsx
+++ b/app-main/pages/vaultDiagram.tsx
@@ -7,14 +7,14 @@ import EditItemModal from '@/components/EditItemModal'
 import { useState, useEffect } from 'react'
 import { parseVault } from '@/lib/parseVault'
 import * as storage from '@/lib/storage'
-import { createTemplate } from '@/lib/sampleVault'
 import { useGraph } from '@/contexts/GraphStore'
 import { useVault } from '@/contexts/VaultStore'
-import { useHiddenStore } from '@/contexts/HiddenStore'
+import { useRouter } from 'next/router'
 
 export default function Vault() {
   const { setGraph } = useGraph()
   const { vault, setVault } = useVault()
+  const router = useRouter()
   const [editIndex, setEditIndex] = useState<number | null>(null)
   const [creating, setCreating] = useState(false)
 
@@ -23,27 +23,20 @@ export default function Vault() {
   const [showHistory, setShowHistory] = useState(false)
   const [shrinkGroups, setShrinkGroups] = useState(false)
 
-  const { clear } = useHiddenStore()
-
-  // Auto-load template if no vault exists
+  // Redirect to onboarding if no vault exists
   useEffect(() => {
     if (!vault) {
-      // Check if there's a saved vault in localStorage first
       const savedVault = storage.loadVault()
       if (savedVault) {
         setVault(savedVault)
         setGraph(parseVault(savedVault))
       } else {
-        // Load template data directly
-        const templateData = createTemplate()
-        setVault(templateData)
-        setGraph(parseVault(templateData))
-        clear()
+        router.push('/vaultOnboarding')
       }
     } else {
       setGraph(parseVault(vault))
     }
-  }, [vault, setVault, setGraph, clear])
+  }, [vault, setVault, setGraph, router])
 
   return (
     <div className="p-4 flex flex-col gap-4 mx-auto px-6">
@@ -55,18 +48,6 @@ export default function Vault() {
             className="px-4 py-2 bg-indigo-600 text-white rounded self-start"
           >
             Version History
-          </button>
-          <button
-            onClick={() => {
-              const templateData = createTemplate()
-              setVault(templateData)
-              setGraph(parseVault(templateData))
-              storage.saveVault(JSON.stringify(templateData))
-              clear()
-            }}
-            className="px-4 py-2 bg-orange-600 text-white rounded self-start hover:bg-orange-700"
-          >
-            Reset to Sample
           </button>
           <label className="flex items-center gap-1 text-sm">
             <input


### PR DESCRIPTION
## Summary
- Redirect to onboarding when no vault exists so diagrams are based on real user data
- Remove template reset controls from vault diagram page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Cannot find module 'openai')*

------
https://chatgpt.com/codex/tasks/task_e_68c174e32cec832ca1aca8fbd1e0e9b0